### PR TITLE
🚨 CRITICAL: Fix task-requirements parameter handling in Argo workflow

### DIFF
--- a/infra/charts/controller/templates/coderun-template.yaml
+++ b/infra/charts/controller/templates/coderun-template.yaml
@@ -99,8 +99,8 @@ spec:
             overwriteMemory: {{`{{workflow.parameters.overwrite-memory}}`}}
             docsBranch: "{{`{{workflow.parameters.docs-branch}}`}}"
             contextVersion: 1
-            {{`{{- if workflow.parameters.task-requirements }}`}}
-            taskRequirements: "{{`{{workflow.parameters.task-requirements}}`}}"
+            {{`{{- if ne (index workflow.parameters "task-requirements") "" }}`}}
+            taskRequirements: "{{`{{index workflow.parameters "task-requirements"}}`}}"
             {{`{{- end }}`}}
             
     - name: wait-coderun-completion


### PR DESCRIPTION
## 🚨 Critical Fix for Task Submission

This fixes the **"manifest must be valid yaml"** error that's preventing all task submissions.

### Problem
The workflow template was failing to parse because Go templates cannot access parameter names with hyphens using dot notation:
- ❌ `workflow.parameters.task-requirements` (invalid syntax) 
- ✅ `index workflow.parameters "task-requirements"` (correct syntax)

### Solution
Updated the workflow template to use the `index` function to properly access the `task-requirements` parameter.

### Impact
- 🔧 **Fixes**: All task submissions that were failing with YAML manifest errors
- 🚀 **Enables**: ArgoCD deployment of workflow templates
- ⚡ **Priority**: Critical - blocks all task execution

### Testing
- [x] Syntax verified against Go template specifications
- [x] Parameter access pattern follows Helm/Argo best practices

### Deployment
This needs to be merged and deployed through ArgoCD immediately to restore task submission functionality.

**Ready for immediate merge** 🚀