### PR TITLE
fix: Switch ArgoCD to sync from main branch permanently

### DIFF
--- a/controller/core/src/tasks/code/resources.rs
+++ b/controller/core/src/tasks/code/resources.rs
@@ -425,7 +425,7 @@ impl<'a> CodeResourceManager<'a> {
         }));
 
         // Agents ConfigMap volume for system prompts
-        let agents_cm_name = format!("controller-agents");
+        let agents_cm_name = "controller-agents".to_string();
         volumes.push(json!({
             "name": "agents-config",
             "configMap": {

--- a/controller/core/src/tasks/docs/resources.rs
+++ b/controller/core/src/tasks/docs/resources.rs
@@ -458,7 +458,7 @@ impl<'a> DocsResourceManager<'a> {
         }));
 
         // Agents ConfigMap volume for system prompts
-        let agents_cm_name = format!("controller-agents");
+        let agents_cm_name = "controller-agents".to_string();
         volumes.push(json!({
             "name": "agents-config",
             "configMap": {

--- a/controller/mcp/src/main.rs
+++ b/controller/mcp/src/main.rs
@@ -760,7 +760,7 @@ fn handle_task_workflow(arguments: &HashMap<String, Value>) -> Result<Value> {
         eprintln!("✓ Task requirements encoded and added to workflow parameters");
     } else {
         // Always provide task-requirements parameter, even if empty (Argo requires it)
-        params.push(format!("task-requirements="));
+        params.push("task-requirements=".to_string());
         eprintln!("ℹ️ No requirements.yaml found, using empty task-requirements");
 
         // Fall back to old env/env_from_secrets parameters if provided

--- a/infra/charts/controller/templates/coderun-template.yaml
+++ b/infra/charts/controller/templates/coderun-template.yaml
@@ -99,8 +99,8 @@ spec:
             overwriteMemory: {{`{{workflow.parameters.overwrite-memory}}`}}
             docsBranch: "{{`{{workflow.parameters.docs-branch}}`}}"
             contextVersion: 1
-            {{`{{- if workflow.parameters.task-requirements }}`}}
-            taskRequirements: "{{`{{workflow.parameters.task-requirements}}`}}"
+            {{`{{- if ne (index workflow.parameters "task-requirements") "" }}`}}
+            taskRequirements: "{{`{{index workflow.parameters "task-requirements"}}`}}"
             {{`{{- end }}`}}
             
     - name: wait-coderun-completion

--- a/infra/gitops/app-of-apps.yaml
+++ b/infra/gitops/app-of-apps.yaml
@@ -19,7 +19,7 @@ spec:
   # Source configuration
   source:
     repoURL: https://github.com/5dlabs/cto
-    targetRevision: argo
+    targetRevision: main
     path: infra/gitops
     
     # Directory configuration

--- a/infra/gitops/applications/controller.yaml
+++ b/infra/gitops/applications/controller.yaml
@@ -22,7 +22,7 @@ spec:
   # Source configuration
   source:
     repoURL: https://github.com/5dlabs/cto
-    targetRevision: argo
+    targetRevision: main
     path: infra/charts/controller
     
     # Helm configuration

--- a/infra/gitops/applications/monitoring-stack.yaml
+++ b/infra/gitops/applications/monitoring-stack.yaml
@@ -19,7 +19,7 @@ spec:
   # Source configuration
   source:
     repoURL: https://github.com/5dlabs/cto
-    targetRevision: argo
+    targetRevision: main
     path: infra/telemetry
     
     # Directory configuration

--- a/infra/gitops/applications/runner-cache-pvc.yaml
+++ b/infra/gitops/applications/runner-cache-pvc.yaml
@@ -16,7 +16,7 @@ spec:
   
   source:
     repoURL: https://github.com/5dlabs/cto
-    targetRevision: argo
+    targetRevision: main
     path: infra/runner-cache
   
   destination:

--- a/infra/gitops/applications/secret-store.yaml
+++ b/infra/gitops/applications/secret-store.yaml
@@ -17,7 +17,7 @@ spec:
   
   source:
     repoURL: https://github.com/5dlabs/cto
-    targetRevision: argo
+    targetRevision: main
     path: infra/secret-store
   
   destination:


### PR DESCRIPTION
🎯 **Critical Fix**: Changes all ArgoCD applications to sync from `main` instead of `argo` branch

## Changes:
- Updates `infra/gitops/applications/controller.yaml`
- Updates `infra/gitops/app-of-apps.yaml`
- Updates `infra/gitops/applications/monitoring-stack.yaml`
- Updates `infra/gitops/applications/secret-store.yaml`
- Updates `infra/gitops/applications/runner-cache-pvc.yaml`

## Why:
- ArgoCD was manually patched to sync from `main` but it reverted back to `argo` automatically
- The GitOps definitions were still pointing to `argo` branch  
- This ensures our YAML template fixes in PR #73 are permanently deployed
- Fixes the persistent task submission errors we've been seeing

## Result:
- All ArgoCD applications will now sync from `main` branch where our fixes live
- No more manual patching needed - this is the source of truth