### PR TITLE
fix(cursor-agent): installer path + CI summary outputs

### DIFF
--- a/infra/images/cursor-agent/Dockerfile
+++ b/infra/images/cursor-agent/Dockerfile
@@ -94,9 +94,15 @@ RUN ARCH=$(dpkg --print-architecture) && \
   sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
   rm "git-delta_0.18.2_${ARCH}.deb"
 
-# Install Cursor CLI (as root to ensure it's available globally)
-RUN curl https://cursor.com/install -fsS | bash && \
-  command -v cursor-agent
+# Install Cursor CLI (as root), then place binary in /usr/local/bin for all users
+RUN set -eux; \
+  curl https://cursor.com/install -fsS | bash; \
+  export PATH="$HOME/.local/bin:$PATH"; \
+  if [ -f "$HOME/.local/bin/cursor-agent" ]; then \
+    install -m 0755 "$HOME/.local/bin/cursor-agent" /usr/local/bin/cursor-agent; \
+  fi; \
+  command -v cursor-agent; \
+  cursor-agent --help >/dev/null 2>&1 || true
 
 # Set up non-root user
 USER node


### PR DESCRIPTION
- Move installed cursor-agent to /usr/local/bin so command is available in non-interactive builds\n- Wire cursor-agent job built output from set-built step to fix summary reporting\n\nFollow-up to #89.