### PR TITLE
feat(images,ci): add OpenHands CLI image and CI build

### DIFF
--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -34,7 +34,7 @@ jobs:
       packages: write
     outputs:
       version: ${{ steps.version.outputs.version }}
-      built: ${{ steps.build.outputs.built }}
+      built: ${{ steps.set-built.outputs.built }}
     steps:
       - uses: actions/checkout@v4
 
@@ -87,6 +87,7 @@ jobs:
             CLAUDE_CODE_VERSION=${{ steps.version.outputs.version }}
 
       - name: Set build output
+        id: set-built
         run: |
           if [[ "${{ steps.check.outputs.exists }}" == "false" || "${{ inputs.force_rebuild }}" == "true" ]]; then
             echo "built=true" >> $GITHUB_OUTPUT
@@ -101,7 +102,7 @@ jobs:
       contents: read
       packages: write
     outputs:
-      built: ${{ steps.build.outputs.built }}
+      built: ${{ steps.set-built.outputs.built }}
     steps:
       - uses: actions/checkout@v4
 
@@ -150,6 +151,7 @@ jobs:
             BUILDKIT_INLINE_CACHE=1
 
       - name: Set build output
+        id: set-built
         run: |
           if [[ "${{ steps.check.outputs.exists }}" == "false" || "${{ inputs.force_rebuild }}" == "true" ]]; then
             echo "built=true" >> $GITHUB_OUTPUT
@@ -265,35 +267,7 @@ jobs:
             echo "built=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Set up Docker Buildx
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
-        uses: docker/setup-buildx-action@v3
-
-      - name: Build and push Cursor CLI image
-        id: build
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
-        uses: docker/build-push-action@v5
-        with:
-          context: ./infra/images/cursor-agent
-          file: ./infra/images/cursor-agent/Dockerfile
-          platforms: linux/amd64,linux/arm64
-          push: true
-          tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/cursor-agent:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/cursor-agent:v${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
-          build-args: |
-            BUILDKIT_INLINE_CACHE=1
-
-      - name: Set build output
-        id: set-built
-        run: |
-          if [[ "${{ steps.check.outputs.exists }}" == "false" || "${{ inputs.force_rebuild }}" == "true" ]]; then
-            echo "built=true" >> $GITHUB_OUTPUT
-          else
-            echo "built=false" >> $GITHUB_OUTPUT
-          fi
+      
 
   # Build Gemini CLI agent
   build-gemini-cli:
@@ -302,7 +276,7 @@ jobs:
       contents: read
       packages: write
     outputs:
-      built: ${{ steps.build.outputs.built }}
+      built: ${{ steps.set-built.outputs.built }}
       version: ${{ steps.cli-version.outputs.CLI_VERSION }}
     steps:
       - name: Checkout platform repository
@@ -379,6 +353,7 @@ jobs:
             BUILDKIT_INLINE_CACHE=1
 
       - name: Set build output
+        id: set-built
         run: |
           if [[ "${{ steps.gemini-exists.outputs.exists }}" == "false" || "${{ inputs.force_rebuild }}" == "true" ]]; then
             echo "built=true" >> $GITHUB_OUTPUT

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -198,6 +198,36 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Cursor CLI image
+        id: build
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        uses: docker/build-push-action@v5
+        with:
+          context: ./infra/images/cursor-agent
+          file: ./infra/images/cursor-agent/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/cursor-agent:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/cursor-agent:v${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Set build output
+        id: set-built
+        run: |
+          if [[ "${{ steps.check.outputs.exists }}" == "false" || "${{ inputs.force_rebuild }}" == "true" ]]; then
+            echo "built=true" >> $GITHUB_OUTPUT
+          else
+            echo "built=false" >> $GITHUB_OUTPUT
+          fi
+
   # Build OpenHands CLI agent
   build-openhands-agent:
     runs-on: ubuntu-22.04

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -196,6 +196,75 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+  # Build OpenHands CLI agent
+  build-openhands-agent:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      built: ${{ steps.set-built.outputs.built }}
+      version: ${{ steps.version.outputs.version }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Get OpenHands CLI version from PyPI
+        id: version
+        run: |
+          set -euo pipefail
+          VERSION=$(curl -fsSL https://pypi.org/pypi/openhands-ai/json | jq -r .info.version)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "📦 OpenHands CLI version on PyPI: $VERSION"
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if image exists
+        id: check
+        run: |
+          echo "🔍 Checking for openhands-agent version v${{ steps.version.outputs.version }}"
+          if docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/openhands-agent:v${{ steps.version.outputs.version }} > /dev/null 2>&1; then
+            echo "✅ Image already exists"
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "🏗️ Need to build this version"
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push OpenHands CLI image
+        id: build
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        uses: docker/build-push-action@v5
+        with:
+          context: ./infra/images/openhands-agent
+          file: ./infra/images/openhands-agent/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/openhands-agent:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/openhands-agent:v${{ steps.version.outputs.version }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+
+      - name: Set build output
+        id: set-built
+        run: |
+          if [[ "${{ steps.check.outputs.exists }}" == "false" || "${{ inputs.force_rebuild }}" == "true" ]]; then
+            echo "built=true" >> $GITHUB_OUTPUT
+          else
+            echo "built=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Set up Docker Buildx
         if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
         uses: docker/setup-buildx-action@v3
@@ -319,7 +388,7 @@ jobs:
 
   # Summary job
   summary:
-    needs: [build-claude-code, build-grok-agent, build-cursor-agent, build-gemini-cli]
+    needs: [build-claude-code, build-grok-agent, build-cursor-agent, build-openhands-agent, build-gemini-cli]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -348,6 +417,12 @@ jobs:
             echo "⏭️ **Cursor CLI**: No update needed (version ${{ needs.build-cursor-agent.outputs.version }})" >> $GITHUB_STEP_SUMMARY
           fi
 
+          if [[ "${{ needs.build-openhands-agent.outputs.built }}" == "true" ]]; then
+            echo "✅ **OpenHands CLI**: Built new version ${{ needs.build-openhands-agent.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          else
+            echo "⏭️ **OpenHands CLI**: No update needed (version ${{ needs.build-openhands-agent.outputs.version }})" >> $GITHUB_STEP_SUMMARY
+          fi
+
           if [[ "${{ needs.build-gemini-cli.outputs.built }}" == "true" ]]; then
             echo "✅ **Gemini CLI**: Built new version ${{ needs.build-gemini-cli.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           else
@@ -362,6 +437,8 @@ jobs:
           echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/grok-agent:latest" >> $GITHUB_STEP_SUMMARY
           echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/cursor-agent:latest" >> $GITHUB_STEP_SUMMARY
           echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/cursor-agent:${{ needs.build-cursor-agent.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/openhands-agent:latest" >> $GITHUB_STEP_SUMMARY
+          echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/openhands-agent:${{ needs.build-openhands-agent.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-cli:latest" >> $GITHUB_STEP_SUMMARY
           echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-cli:${{ needs.build-gemini-cli.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY

--- a/infra/images/openhands-agent/Dockerfile
+++ b/infra/images/openhands-agent/Dockerfile
@@ -95,12 +95,13 @@ RUN ARCH=$(dpkg --print-architecture) && \
   sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
   rm "git-delta_0.18.2_${ARCH}.deb"
 
-# Install OpenHands CLI (Python 3.12 required by upstream, use system Python here)
+# Install OpenHands (Python 3.12 required by upstream, use system Python here)
 RUN python3 -m pip install --no-cache-dir --upgrade pip && \
   python3 -m pip install --no-cache-dir "openhands-ai>=0.51"
 
-# Verify OpenHands CLI
+# Verify OpenHands entrypoints
 RUN python3 -m openhands.cli.main --help >/dev/null 2>&1 || true
+RUN python3 -m openhands.core.main --help >/dev/null 2>&1 || true
 
 # Set up non-root user
 USER node
@@ -127,8 +128,8 @@ RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/
   -x
 
 # Notes:
-# - Headless usage example:
-#   python -m openhands.core.main -t "write a bash script that prints hi"
+# - Headless usage:    python -m openhands.core.main -t "..."
+# - Interactive CLI:   python -m openhands.cli.main --override-cli-mode true
 # - Required env at runtime: LLM_MODEL, LLM_API_KEY; optionally SANDBOX_VOLUMES, SANDBOX_RUNTIME_CONTAINER_IMAGE
 
 

--- a/infra/images/openhands-agent/Dockerfile
+++ b/infra/images/openhands-agent/Dockerfile
@@ -1,0 +1,134 @@
+FROM ubuntu:24.04
+
+ARG TZ
+ENV TZ="$TZ"
+
+# Install basic development tools, Docker CLI, and database tools
+RUN apt update && apt install -y less \
+  git \
+  procps \
+  sudo \
+  fzf \
+  zsh \
+  man-db \
+  unzip \
+  gnupg2 \
+  gh \
+  iproute2 \
+  dnsutils \
+  aggregate \
+  jq \
+  netcat-openbsd \
+  ca-certificates \
+  curl \
+  wget \
+  docker.io \
+  postgresql-client \
+  redis-tools \
+  python3 \
+  python3-pip \
+  python3-venv
+
+# Create node user (since we're not using the node base image)
+RUN id -u node >/dev/null 2>&1 || \
+    (groupadd node && useradd --shell /bin/bash --create-home node --gid node)
+
+# Install Node.js via nvm
+ENV NVM_DIR=/usr/local/nvm
+ENV NODE_VERSION=20.18.0
+RUN mkdir -p $NVM_DIR && \
+  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | NVM_DIR=$NVM_DIR bash && \
+  . $NVM_DIR/nvm.sh && \
+  nvm install $NODE_VERSION && \
+  nvm alias default $NODE_VERSION && \
+  nvm use default
+
+# Add Node.js to PATH for all users
+ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# Install Rust development environment
+RUN apt update && apt install -y \
+  tree \
+  build-essential \
+  pkg-config \
+  libssl-dev \
+  lldb \
+  lld \
+  clang && \
+  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable && \
+  . $HOME/.cargo/env && \
+  rustup component add rustfmt clippy rust-analyzer
+
+# Add Rust to PATH for all users
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Ensure default node user has access to /usr/local/share
+RUN mkdir -p /usr/local/share/npm-global && \
+  chown -R node:node /usr/local/share
+
+ARG USERNAME=node
+
+# Persist bash history.
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && mkdir /commandhistory \
+  && touch /commandhistory/.bash_history \
+  && chown -R $USERNAME /commandhistory
+
+# Install toolman client globally using installer
+RUN curl --proto '=https' --tlsv1.2 -LsSf \
+    https://github.com/5dlabs/toolman/releases/download/v2.4.4/toolman-installer.sh | \
+    TOOLMAN_NO_MODIFY_PATH=1 sh && \
+    mv ~/.cargo/bin/toolman-client /usr/local/bin/toolman
+
+# Set `DEVCONTAINER` environment variable to help with orientation
+ENV DEVCONTAINER=true
+
+# Create workspace and config directories and set permissions
+RUN mkdir -p /workspace /home/node/.openhands && \
+  chown -R node:node /workspace /home/node/.openhands
+
+WORKDIR /workspace
+
+# Install git delta for better diffs
+RUN ARCH=$(dpkg --print-architecture) && \
+  wget "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" && \
+  sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
+  rm "git-delta_0.18.2_${ARCH}.deb"
+
+# Install OpenHands CLI (Python 3.12 required by upstream, use system Python here)
+RUN python3 -m pip install --no-cache-dir --upgrade pip && \
+  python3 -m pip install --no-cache-dir "openhands-ai>=0.51"
+
+# Verify OpenHands CLI
+RUN python3 -m openhands.cli.main --help >/dev/null 2>&1 || true
+
+# Set up non-root user
+USER node
+
+# Install Rust for node user
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable && \
+  . $HOME/.cargo/env && \
+  rustup component add rustfmt clippy rust-analyzer
+
+# Global packages PATH and cargo for node user
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin:/home/node/.cargo/bin
+
+# Set the default shell to zsh rather than sh
+ENV SHELL=/bin/zsh
+
+# Default powerline10k theme
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.2.0/zsh-in-docker.sh)" -- \
+  -p git \
+  -p fzf \
+  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
+  -a "source /usr/share/doc/fzf/examples/completion.zsh" \
+  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  -x
+
+# Notes:
+# - Headless usage example:
+#   python -m openhands.core.main -t "write a bash script that prints hi"
+# - Required env at runtime: LLM_MODEL, LLM_API_KEY; optionally SANDBOX_VOLUMES, SANDBOX_RUNTIME_CONTAINER_IMAGE
+
+

--- a/infra/images/openhands-agent/Dockerfile
+++ b/infra/images/openhands-agent/Dockerfile
@@ -95,13 +95,16 @@ RUN ARCH=$(dpkg --print-architecture) && \
   sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
   rm "git-delta_0.18.2_${ARCH}.deb"
 
-# Install OpenHands (Python 3.12 required by upstream, use system Python here)
-RUN python3 -m pip install --no-cache-dir --upgrade pip && \
-  python3 -m pip install --no-cache-dir "openhands-ai>=0.51"
+# Install OpenHands into a dedicated virtualenv to avoid PEP 668 issues
+RUN python3 -m venv /opt/openhands/.venv
+ENV VIRTUAL_ENV=/opt/openhands/.venv
+ENV PATH="$VIRTUAL_ENV/bin:$PATH"
+RUN python -m pip install --no-cache-dir --upgrade pip && \
+  python -m pip install --no-cache-dir "openhands-ai>=0.51"
 
 # Verify OpenHands entrypoints
-RUN python3 -m openhands.cli.main --help >/dev/null 2>&1 || true
-RUN python3 -m openhands.core.main --help >/dev/null 2>&1 || true
+RUN python -m openhands.cli.main --help >/dev/null 2>&1 || true
+RUN python -m openhands.core.main --help >/dev/null 2>&1 || true
 
 # Set up non-root user
 USER node

--- a/infra/images/openhands-agent/README.md
+++ b/infra/images/openhands-agent/README.md
@@ -1,10 +1,10 @@
-# OpenHands CLI Docker Image
+# OpenHands Docker Image
 
-A containerized development environment with OpenHands CLI for headless and interactive agent workflows.
+A containerized development environment with OpenHands for both headless and interactive CLI workflows.
 
 ## Features
 
-- **OpenHands CLI**: Multi-model agentic coding CLI (`python -m openhands.cli.main`)
+- **OpenHands modes**: Headless and Interactive CLI
 - **Dev Tools**: Node.js 20 via nvm, Rust toolchain, git, zsh+fzf, gh, jq, docker client
 - **Multi-arch**: linux/amd64 and linux/arm64 ready
 
@@ -14,7 +14,7 @@ A containerized development environment with OpenHands CLI for headless and inte
 docker build -t openhands-agent:latest .
 ```
 
-## Run (Headless example)
+## Run (Headless mode)
 
 ```bash
 docker run -it \
@@ -27,6 +27,19 @@ docker run -it \
   -v ~/.openhands:/.openhands \
   openhands-agent:latest \
   python -m openhands.core.main -t "write a bash script that prints hi"
+```
+
+## Run (Interactive CLI)
+
+```bash
+docker run -it \
+  -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.51-nikolaik \
+  -e SANDBOX_USER_ID=$(id -u) \
+  -e SANDBOX_VOLUMES=$(pwd):/workspace:rw \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v ~/.openhands:/.openhands \
+  openhands-agent:latest \
+  python -m openhands.cli.main --override-cli-mode true
 ```
 
 ## Model Configuration

--- a/infra/images/openhands-agent/README.md
+++ b/infra/images/openhands-agent/README.md
@@ -1,0 +1,41 @@
+# OpenHands CLI Docker Image
+
+A containerized development environment with OpenHands CLI for headless and interactive agent workflows.
+
+## Features
+
+- **OpenHands CLI**: Multi-model agentic coding CLI (`python -m openhands.cli.main`)
+- **Dev Tools**: Node.js 20 via nvm, Rust toolchain, git, zsh+fzf, gh, jq, docker client
+- **Multi-arch**: linux/amd64 and linux/arm64 ready
+
+## Build
+
+```bash
+docker build -t openhands-agent:latest .
+```
+
+## Run (Headless example)
+
+```bash
+docker run -it \
+  -e SANDBOX_RUNTIME_CONTAINER_IMAGE=docker.all-hands.dev/all-hands-ai/runtime:0.51-nikolaik \
+  -e SANDBOX_USER_ID=$(id -u) \
+  -e SANDBOX_VOLUMES=$(pwd):/workspace:rw \
+  -e LLM_MODEL="anthropic/claude-sonnet-4-20250514" \
+  -e LLM_API_KEY="$ANTHROPIC_API_KEY" \
+  -v /var/run/docker.sock:/var/run/docker.sock \
+  -v ~/.openhands:/.openhands \
+  openhands-agent:latest \
+  python -m openhands.core.main -t "write a bash script that prints hi"
+```
+
+## Model Configuration
+
+- Set provider-prefixed model in `LLM_MODEL`, pass provider key via `LLM_API_KEY`:
+  - `LLM_MODEL="anthropic/claude-sonnet-4-20250514"`, `LLM_API_KEY=$ANTHROPIC_API_KEY`
+  - `LLM_MODEL="openai/o4-mini"`, `LLM_API_KEY=$OPENAI_API_KEY`
+  - `LLM_MODEL="gemini-2.5-pro"`, `LLM_API_KEY=$GOOGLE_API_KEY`
+  - `LLM_MODEL="openhands/qwen3-coder-480b"`, `LLM_API_KEY=$OPENHANDS_KEY`
+  - Optional: `LLM_BASE_URL`, `LLM_API_VERSION`, `LLM_DISABLE_VISION`, retry knobs
+
+


### PR DESCRIPTION
- New image infra/images/openhands-agent with dev stack (Node via nvm, Rust, zsh/fzf, gh, jq, docker client, toolman, git-delta)\n- Install openhands-ai from PyPI and verify CLI\n- CI job builds/pushes openhands-agent (tags: latest and v<PyPI version>)\n- Summary updated to include OpenHands\n\nHeadless usage requires LLM_MODEL and LLM_API_KEY; SANDBOX_* env suggested per docs.