### PR TITLE
feature/agent runtime base

### DIFF
--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -63,8 +63,12 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Set up QEMU (multi-arch emulation)
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push base image
@@ -129,6 +133,10 @@ jobs:
             echo "🏗️ Need to build this version"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set up QEMU (multi-arch emulation)
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
@@ -196,6 +204,10 @@ jobs:
             echo "🏗️ Need to build this version"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set up QEMU (multi-arch emulation)
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
@@ -268,8 +280,12 @@ jobs:
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
+      - name: Set up QEMU (multi-arch emulation)
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
+        uses: docker/setup-qemu-action@v3
+
       - name: Set up Docker Buildx
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push Cursor CLI image
@@ -337,6 +353,10 @@ jobs:
             echo "🏗️ Need to build this version"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set up QEMU (multi-arch emulation)
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
@@ -431,6 +451,10 @@ jobs:
             echo "🏗️ We haven't built this version yet, will build"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
+
+      - name: Set up QEMU (multi-arch emulation)
+        if: steps.gemini-exists.outputs.exists == 'false' || inputs.force_rebuild == true
+        uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
         if: steps.gemini-exists.outputs.exists == 'false' || inputs.force_rebuild == true

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -10,8 +10,11 @@ on:
     - cron: '0 6 * * *'
 
   push:
+    branches:
+      - '**'
     paths:
       - 'infra/images/**'
+      - '.github/workflows/agents.yml'
 
   workflow_dispatch:
     inputs:
@@ -351,8 +354,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/openhands-agent:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/openhands-agent:v${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
 

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -75,8 +75,10 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ steps.tag.outputs.tag }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # GitHub's default docker driver on ubuntu runners doesn't support cache export.
+          # Disable cache-to and rely on registry/layer caching instead.
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
 
       - name: Set build output
         id: set-built
@@ -126,7 +128,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push Claude Code image
@@ -141,8 +143,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/claude-code:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/claude-code:v${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ needs.build-agent-runtime-base.outputs.tag }}
@@ -208,8 +210,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/grok-agent:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/grok-agent:v${{ steps.check.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ needs.build-agent-runtime-base.outputs.tag }}
@@ -279,8 +281,8 @@ jobs:
           tags: |
             ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/cursor-agent:latest
             ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/cursor-agent:v${{ steps.version.outputs.version }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ needs.build-agent-runtime-base.outputs.tag }}

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -145,6 +145,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ needs.build-agent-runtime-base.outputs.tag }}
             CLAUDE_CODE_VERSION=${{ steps.version.outputs.version }}
 
       - name: Set build output

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -26,8 +26,69 @@ env:
   IMAGE_BASE: ${{ github.repository }}
 
 jobs:
+  build-agent-runtime-base:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    outputs:
+      built: ${{ steps.set-built.outputs.built }}
+      tag: ${{ steps.tag.outputs.tag }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Compute base tag (git hash of Dockerfile)
+        id: tag
+        run: |
+          set -euo pipefail
+          HASH=$(git log -1 --format="%h" -- infra/images/agent-runtime-base/Dockerfile)
+          echo "tag=$HASH" >> $GITHUB_OUTPUT
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Check if base image exists
+        id: check
+        run: |
+          if docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ steps.tag.outputs.tag }} > /dev/null 2>&1; then
+            echo "exists=true" >> $GITHUB_OUTPUT
+          else
+            echo "exists=false" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Set up Docker Buildx
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push base image
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        uses: docker/build-push-action@v5
+        with:
+          context: ./infra/images/agent-runtime-base
+          file: ./infra/images/agent-runtime-base/Dockerfile
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ steps.tag.outputs.tag }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Set build output
+        id: set-built
+        run: |
+          if [[ "${{ steps.check.outputs.exists }}" == "false" || "${{ inputs.force_rebuild }}" == "true" ]]; then
+            echo "built=true" >> $GITHUB_OUTPUT
+          else
+            echo "built=false" >> $GITHUB_OUTPUT
+          fi
   # Build Claude Code agent
   build-claude-code:
+    needs: build-agent-runtime-base
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -97,6 +158,7 @@ jobs:
 
   # Build Grok agent
   build-grok-agent:
+    needs: build-agent-runtime-base
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -149,6 +211,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ needs.build-agent-runtime-base.outputs.tag }}
 
       - name: Set build output
         id: set-built

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -61,7 +61,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push base image
@@ -131,7 +131,7 @@ jobs:
 
       - name: Build and push Claude Code image
         id: build
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/build-push-action@v5
         with:
           context: ./infra/images/claude-code
@@ -193,12 +193,12 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push Grok agent image
         id: build
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/build-push-action@v5
         with:
           context: ./infra/images/grok-agent

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -225,6 +225,7 @@ jobs:
 
   # Build Cursor CLI agent
   build-cursor-agent:
+    needs: build-agent-runtime-base
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -268,7 +269,7 @@ jobs:
 
       - name: Build and push Cursor CLI image
         id: build
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/build-push-action@v5
         with:
           context: ./infra/images/cursor-agent
@@ -282,6 +283,7 @@ jobs:
           cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ needs.build-agent-runtime-base.outputs.tag }}
 
       - name: Set build output
         id: set-built

--- a/.github/workflows/agents.yml
+++ b/.github/workflows/agents.yml
@@ -317,6 +317,7 @@ jobs:
 
   # Build OpenHands CLI agent
   build-openhands-agent:
+    needs: build-agent-runtime-base
     runs-on: ubuntu-22.04
     permissions:
       contents: read
@@ -355,16 +356,16 @@ jobs:
           fi
 
       - name: Set up QEMU (multi-arch emulation)
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/setup-buildx-action@v3
 
       - name: Build and push OpenHands CLI image
         id: build
-        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/build-push-action@v5
         with:
           context: ./infra/images/openhands-agent
@@ -378,6 +379,7 @@ jobs:
           # cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ needs.build-agent-runtime-base.outputs.tag }}
 
       - name: Set build output
         id: set-built
@@ -390,47 +392,25 @@ jobs:
 
       
 
-  # Build Gemini CLI agent
-  build-gemini-cli:
+  # Build Gemini agent
+  build-gemini-agent:
+    needs: build-agent-runtime-base
     runs-on: ubuntu-22.04
     permissions:
       contents: read
       packages: write
     outputs:
       built: ${{ steps.set-built.outputs.built }}
-      version: ${{ steps.cli-version.outputs.CLI_VERSION }}
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Checkout platform repository
-        uses: actions/checkout@v4
+      - uses: actions/checkout@v4
 
-      - name: Checkout Gemini CLI repository
-        uses: actions/checkout@v4
-        with:
-          repository: google-gemini/gemini-cli
-          ref: main
-          path: gemini-cli
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: '20'
-          cache: 'npm'
-          cache-dependency-path: gemini-cli/package-lock.json
-
-      - name: Install dependencies and build packages
-        working-directory: ./gemini-cli
+      - name: Get Gemini CLI version
+        id: version
         run: |
-          npm ci
-          npm run build:packages
-          npm pack -w @google/gemini-cli --pack-destination ./packages/cli/dist
-          npm pack -w @google/gemini-cli-core --pack-destination ./packages/core/dist
-
-      - name: Get CLI version
-        id: cli-version
-        working-directory: ./gemini-cli
-        run: |
-          CLI_VERSION=$(node -p "require('./packages/cli/package.json').version")
-          echo "CLI_VERSION=$CLI_VERSION" >> $GITHUB_OUTPUT
-          echo "📦 Gemini CLI version from source: $CLI_VERSION"
+          VERSION=$(npm view @google/gemini-cli version)
+          echo "version=$VERSION" >> $GITHUB_OUTPUT
+          echo "📦 Gemini CLI version on npm: $VERSION"
 
       - name: Log in to Container Registry
         uses: docker/login-action@v3
@@ -439,48 +419,49 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Check if Gemini CLI image exists
-        id: gemini-exists
+      - name: Check if image exists
+        id: check
         run: |
-          echo "🔍 Checking if we have built Gemini CLI version ${{ steps.cli-version.outputs.CLI_VERSION }}"
-          echo "Looking for: ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-cli:${{ steps.cli-version.outputs.CLI_VERSION }}"
-          if docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-cli:v${{ steps.cli-version.outputs.CLI_VERSION }} > /dev/null 2>&1; then
-            echo "✅ We already have this version built, skipping build"
+          echo "🔍 Checking for gemini-agent version v${{ steps.version.outputs.version }}"
+          if docker manifest inspect ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-agent:v${{ steps.version.outputs.version }} > /dev/null 2>&1; then
+            echo "✅ Image already exists"
             echo "exists=true" >> $GITHUB_OUTPUT
           else
-            echo "🏗️ We haven't built this version yet, will build"
+            echo "🏗️ Need to build this version"
             echo "exists=false" >> $GITHUB_OUTPUT
           fi
 
       - name: Set up QEMU (multi-arch emulation)
-        if: steps.gemini-exists.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/setup-qemu-action@v3
 
       - name: Set up Docker Buildx
-        if: steps.gemini-exists.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/setup-buildx-action@v3
 
-      - name: Build and push Gemini CLI image
+      - name: Build and push Gemini agent image
         id: build
-        if: steps.gemini-exists.outputs.exists == 'false' || inputs.force_rebuild == true
+        if: steps.check.outputs.exists == 'false' || inputs.force_rebuild == true || needs.build-agent-runtime-base.outputs.built == 'true'
         uses: docker/build-push-action@v5
         with:
-          context: ./gemini-cli
-          file: ./gemini-cli/Dockerfile
+          context: ./infra/images/gemini-agent
+          file: ./infra/images/gemini-agent/Dockerfile
           platforms: linux/amd64,linux/arm64
           push: true
           tags: |
-            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-cli:latest
-            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-cli:v${{ steps.cli-version.outputs.CLI_VERSION }}
-          cache-from: type=gha
-          cache-to: type=gha,mode=max
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-agent:latest
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-agent:v${{ steps.version.outputs.version }}
+          # cache-from: type=gha
+          # cache-to: type=gha,mode=max
           build-args: |
             BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:v${{ needs.build-agent-runtime-base.outputs.tag }}
+            CLI_VERSION=${{ steps.version.outputs.version }}
 
       - name: Set build output
         id: set-built
         run: |
-          if [[ "${{ steps.gemini-exists.outputs.exists }}" == "false" || "${{ inputs.force_rebuild }}" == "true" ]]; then
+          if [[ "${{ steps.check.outputs.exists }}" == "false" || "${{ inputs.force_rebuild }}" == "true" ]]; then
             echo "built=true" >> $GITHUB_OUTPUT
           else
             echo "built=false" >> $GITHUB_OUTPUT
@@ -488,7 +469,7 @@ jobs:
 
   # Summary job
   summary:
-    needs: [build-claude-code, build-grok-agent, build-cursor-agent, build-openhands-agent, build-gemini-cli]
+    needs: [build-claude-code, build-grok-agent, build-cursor-agent, build-openhands-agent, build-gemini-agent]
     if: always()
     runs-on: ubuntu-latest
     steps:
@@ -523,10 +504,10 @@ jobs:
             echo "⏭️ **OpenHands CLI**: No update needed (version ${{ needs.build-openhands-agent.outputs.version }})" >> $GITHUB_STEP_SUMMARY
           fi
 
-          if [[ "${{ needs.build-gemini-cli.outputs.built }}" == "true" ]]; then
-            echo "✅ **Gemini CLI**: Built new version ${{ needs.build-gemini-cli.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          if [[ "${{ needs.build-gemini-agent.outputs.built }}" == "true" ]]; then
+            echo "✅ **Gemini Agent**: Built new version ${{ needs.build-gemini-agent.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           else
-            echo "⏭️ **Gemini CLI**: No update needed (version ${{ needs.build-gemini-cli.outputs.version }})" >> $GITHUB_STEP_SUMMARY
+            echo "⏭️ **Gemini Agent**: No update needed (version ${{ needs.build-gemini-agent.outputs.version }})" >> $GITHUB_STEP_SUMMARY
           fi
 
           echo "" >> $GITHUB_STEP_SUMMARY
@@ -539,8 +520,8 @@ jobs:
           echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/cursor-agent:${{ needs.build-cursor-agent.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/openhands-agent:latest" >> $GITHUB_STEP_SUMMARY
           echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/openhands-agent:${{ needs.build-openhands-agent.outputs.version }}" >> $GITHUB_STEP_SUMMARY
-          echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-cli:latest" >> $GITHUB_STEP_SUMMARY
-          echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-cli:${{ needs.build-gemini-cli.outputs.version }}" >> $GITHUB_STEP_SUMMARY
+          echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-agent:latest" >> $GITHUB_STEP_SUMMARY
+          echo "${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-agent:${{ needs.build-gemini-agent.outputs.version }}" >> $GITHUB_STEP_SUMMARY
           echo "\`\`\`" >> $GITHUB_STEP_SUMMARY
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "🔄 **Next run**: Tomorrow at 6 AM UTC (or trigger manually)" >> $GITHUB_STEP_SUMMARY

--- a/.github/workflows/claude-code-test.yml
+++ b/.github/workflows/claude-code-test.yml
@@ -1,0 +1,55 @@
+name: Claude Code Test (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: 'Base image tag (e.g., latest or v<hash>)'
+        required: false
+        default: 'latest'
+      version:
+        description: 'Claude Code CLI version (defaults to latest)'
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BASE: ${{ github.repository }}
+
+jobs:
+  build-claude-test:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Claude Code test image (amd64 only)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./infra/images/claude-code
+          file: ./infra/images/claude-code/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/claude-code:test
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:${{ inputs.base_tag }}
+            CLAUDE_CODE_VERSION=${{ inputs.version }}
+
+

--- a/.github/workflows/cursor-agent-test.yml
+++ b/.github/workflows/cursor-agent-test.yml
@@ -1,0 +1,50 @@
+name: Cursor Agent Test (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: 'Base image tag (e.g., latest or v<hash>)'
+        required: false
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BASE: ${{ github.repository }}
+
+jobs:
+  build-cursor-test:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Cursor test image (amd64 only)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./infra/images/cursor-agent
+          file: ./infra/images/cursor-agent/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/cursor-agent:test
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:${{ inputs.base_tag }}
+
+

--- a/.github/workflows/gemini-agent-test.yml
+++ b/.github/workflows/gemini-agent-test.yml
@@ -1,0 +1,55 @@
+name: Gemini Agent Test (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: 'Base image tag (e.g., latest or v<hash>)'
+        required: false
+        default: 'latest'
+      version:
+        description: 'Gemini CLI version from npm (empty = latest)'
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BASE: ${{ github.repository }}
+
+jobs:
+  build-gemini-test:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Gemini test image (amd64 only)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./infra/images/gemini-agent
+          file: ./infra/images/gemini-agent/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/gemini-agent:test
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:${{ inputs.base_tag }}
+            CLI_VERSION=${{ inputs.version }}
+
+

--- a/.github/workflows/gemini-agent-test.yml
+++ b/.github/workflows/gemini-agent-test.yml
@@ -7,8 +7,8 @@ on:
         description: 'Base image tag (e.g., latest or v<hash>)'
         required: false
         default: 'latest'
-      version:
-        description: 'Gemini CLI version from npm (empty = latest)'
+      cli_version:
+        description: 'Gemini CLI version (defaults to latest)'
         required: false
         default: ''
 
@@ -50,6 +50,6 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:${{ inputs.base_tag }}
-            CLI_VERSION=${{ inputs.version }}
+            CLI_VERSION=${{ inputs.cli_version }}
 
-
+ 

--- a/.github/workflows/grok-agent-test.yml
+++ b/.github/workflows/grok-agent-test.yml
@@ -1,0 +1,50 @@
+name: Grok Agent Test (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: 'Base image tag (e.g., latest or v<hash>)'
+        required: false
+        default: 'latest'
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BASE: ${{ github.repository }}
+
+jobs:
+  build-grok-test:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Grok test image (amd64 only)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./infra/images/grok-agent
+          file: ./infra/images/grok-agent/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/grok-agent:test
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:${{ inputs.base_tag }}
+
+

--- a/.github/workflows/openhands-agent-test.yml
+++ b/.github/workflows/openhands-agent-test.yml
@@ -7,10 +7,6 @@ on:
         description: 'Base image tag (e.g., latest or v<hash>)'
         required: false
         default: 'latest'
-      version:
-        description: 'OpenHands CLI version from PyPI (empty = latest)'
-        required: false
-        default: ''
 
 env:
   REGISTRY: ghcr.io
@@ -50,6 +46,5 @@ jobs:
           build-args: |
             BUILDKIT_INLINE_CACHE=1
             BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:${{ inputs.base_tag }}
-            OPENHANDS_VERSION=${{ inputs.version }}
 
 

--- a/.github/workflows/openhands-agent-test.yml
+++ b/.github/workflows/openhands-agent-test.yml
@@ -1,0 +1,55 @@
+name: OpenHands Agent Test (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      base_tag:
+        description: 'Base image tag (e.g., latest or v<hash>)'
+        required: false
+        default: 'latest'
+      version:
+        description: 'OpenHands CLI version from PyPI (empty = latest)'
+        required: false
+        default: ''
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BASE: ${{ github.repository }}
+
+jobs:
+  build-openhands-test:
+    runs-on: ubuntu-22.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push OpenHands test image (amd64 only)
+        uses: docker/build-push-action@v5
+        with:
+          context: ./infra/images/openhands-agent
+          file: ./infra/images/openhands-agent/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/openhands-agent:test
+          build-args: |
+            BUILDKIT_INLINE_CACHE=1
+            BASE_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_BASE }}/agent-runtime-base:${{ inputs.base_tag }}
+            OPENHANDS_VERSION=${{ inputs.version }}
+
+

--- a/infra/images/agent-runtime-base/Dockerfile
+++ b/infra/images/agent-runtime-base/Dockerfile
@@ -1,3 +1,4 @@
+## CI trigger: no-op change to run Agent Images workflow
 FROM ubuntu:24.04
 
 ARG TZ

--- a/infra/images/agent-runtime-base/Dockerfile
+++ b/infra/images/agent-runtime-base/Dockerfile
@@ -1,0 +1,79 @@
+FROM ubuntu:24.04
+
+ARG TZ
+ENV TZ="$TZ"
+
+# Core tools and CLIs
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  git procps sudo fzf zsh man-db unzip gnupg2 gh iproute2 dnsutils jq \
+  netcat-openbsd ca-certificates curl wget docker.io postgresql-client \
+  redis-tools tree build-essential pkg-config libssl-dev lldb lld clang \
+  && rm -rf /var/lib/apt/lists/*
+
+# Create non-root user 'node' to match existing agents
+RUN id -u node >/dev/null 2>&1 || (groupadd node && useradd --shell /bin/bash --create-home node --gid node)
+
+# Install Node via nvm
+ENV NVM_DIR=/usr/local/nvm
+ENV NODE_VERSION=20.18.0
+RUN mkdir -p $NVM_DIR \
+  && curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | NVM_DIR=$NVM_DIR bash \
+  && . $NVM_DIR/nvm.sh \
+  && nvm install $NODE_VERSION \
+  && nvm alias default $NODE_VERSION \
+  && nvm use default
+ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
+
+# Install Rust toolchain for root
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable \
+  && . $HOME/.cargo/env \
+  && rustup component add rustfmt clippy rust-analyzer
+ENV PATH="/root/.cargo/bin:${PATH}"
+
+# Prepare npm global and permissions
+RUN mkdir -p /usr/local/share/npm-global && chown -R node:node /usr/local/share
+
+# Persist bash history for convenience
+ARG USERNAME=node
+RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
+  && mkdir /commandhistory \
+  && touch /commandhistory/.bash_history \
+  && chown -R $USERNAME /commandhistory
+
+# Install toolman client
+RUN curl --proto '=https' --tlsv1.2 -LsSf \
+    https://github.com/5dlabs/toolman/releases/download/v2.4.4/toolman-installer.sh | \
+    TOOLMAN_NO_MODIFY_PATH=1 sh \
+  && mv ~/.cargo/bin/toolman-client /usr/local/bin/toolman
+
+# Install git-delta
+RUN ARCH=$(dpkg --print-architecture) \
+  && wget -q "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" \
+  && dpkg -i "git-delta_0.18.2_${ARCH}.deb" \
+  && rm -f "git-delta_0.18.2_${ARCH}.deb"
+
+# Switch to non-root and install Rust for node as well
+USER node
+RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable \
+  && . $HOME/.cargo/env \
+  && rustup component add rustfmt clippy rust-analyzer
+
+# Global npm config and PATH
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin:/home/node/.cargo/bin
+
+# Zsh and prompt setup
+ENV SHELL=/bin/zsh
+RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.2.0/zsh-in-docker.sh)" -- \
+  -p git \
+  -p fzf \
+  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
+  -a "source /usr/share/doc/fzf/examples/completion.zsh" \
+  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" -x
+
+# Labels / defaults
+USER node
+WORKDIR /workspace
+ENV DEVCONTAINER=true
+
+

--- a/infra/images/claude-code/Dockerfile
+++ b/infra/images/claude-code/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ghcr.io/5dlabs/cto/agent-runtime-base:latest
 FROM ${BASE_IMAGE}
 
 ARG TZ

--- a/infra/images/claude-code/Dockerfile
+++ b/infra/images/claude-code/Dockerfile
@@ -1,120 +1,15 @@
-FROM ubuntu:24.04
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 ARG TZ
 ENV TZ="$TZ"
 
-# Install basic development tools, Docker CLI, and database tools
-RUN apt update && apt install -y less \
-  git \
-  procps \
-  sudo \
-  fzf \
-  zsh \
-  man-db \
-  unzip \
-  gnupg2 \
-  gh \
-  iproute2 \
-  dnsutils \
-  aggregate \
-  jq \
-  netcat-openbsd \
-  ca-certificates \
-  curl \
-  wget \
-  docker.io \
-  postgresql-client \
-  redis-tools
-
-# Create node user (since we're not using the node base image)
-RUN id -u node >/dev/null 2>&1 || \
-    (groupadd node && useradd --shell /bin/bash --create-home node --gid node)
-
-# Install Node.js via nvm
-ENV NVM_DIR=/usr/local/nvm
-ENV NODE_VERSION=20.18.0
-RUN mkdir -p $NVM_DIR && \
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | NVM_DIR=$NVM_DIR bash && \
-  . $NVM_DIR/nvm.sh && \
-  nvm install $NODE_VERSION && \
-  nvm alias default $NODE_VERSION && \
-  nvm use default
-
-# Add Node.js to PATH for all users
-ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-
-# Install Rust development environment
-RUN apt update && apt install -y \
-  curl \
-  tree \
-  build-essential \
-  pkg-config \
-  libssl-dev \
-  lldb \
-  lld \
-  clang && \
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable && \
-  . $HOME/.cargo/env && \
-  rustup component add rustfmt clippy rust-analyzer
-
-# Add Rust to PATH for all users
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Ensure default node user has access to /usr/local/share
-RUN mkdir -p /usr/local/share/npm-global && \
-  chown -R node:node /usr/local/share
-
 ARG USERNAME=node
-
-# Persist bash history.
-RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-  && mkdir /commandhistory \
-  && touch /commandhistory/.bash_history \
-  && chown -R $USERNAME /commandhistory
-
-# Install toolman client globally using installer
-RUN curl --proto '=https' --tlsv1.2 -LsSf \
-    https://github.com/5dlabs/toolman/releases/download/v2.4.4/toolman-installer.sh | \
-    TOOLMAN_NO_MODIFY_PATH=1 sh && \
-    mv ~/.cargo/bin/toolman-client /usr/local/bin/toolman
-
-# Set `DEVCONTAINER` environment variable to help with orientation
 ENV DEVCONTAINER=true
-
-# Create workspace and config directories and set permissions
 RUN mkdir -p /workspace /home/node/.claude && \
   chown -R node:node /workspace /home/node/.claude
-
 WORKDIR /workspace
-
-RUN ARCH=$(dpkg --print-architecture) && \
-  wget "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" && \
-  sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
-  rm "git-delta_0.18.2_${ARCH}.deb"
-
-# Set up non-root user
 USER node
-
-# Install Rust for node user
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable && \
-  . $HOME/.cargo/env && \
-  rustup component add rustfmt clippy rust-analyzer
-
-# Install global packages
-ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
-ENV PATH=$PATH:/usr/local/share/npm-global/bin:/home/node/.cargo/bin
-
-# Set the default shell to zsh rather than sh
-ENV SHELL=/bin/zsh
-
-# Default powerline10k theme
-RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.2.0/zsh-in-docker.sh)" -- \
-  -p git \
-  -p fzf \
-  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
-  -a "source /usr/share/doc/fzf/examples/completion.zsh" \
-  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-  -x
 
 # Install Claude
 ARG CLAUDE_CODE_VERSION=latest

--- a/infra/images/cursor-agent/Dockerfile
+++ b/infra/images/cursor-agent/Dockerfile
@@ -11,6 +11,7 @@ RUN mkdir -p /workspace /home/node/.cursor && \
 WORKDIR /workspace
 
 # Install Cursor CLI (as root), then place binary in /usr/local/bin for all users
+USER root
 RUN set -eux; \
   curl https://cursor.com/install -fsS | bash; \
   export PATH="$HOME/.local/bin:$PATH"; \

--- a/infra/images/cursor-agent/Dockerfile
+++ b/infra/images/cursor-agent/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ghcr.io/5dlabs/cto/agent-runtime-base:latest
 FROM ${BASE_IMAGE}
 
 ARG TZ

--- a/infra/images/cursor-agent/Dockerfile
+++ b/infra/images/cursor-agent/Dockerfile
@@ -1,98 +1,14 @@
-FROM ubuntu:24.04
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
 ARG TZ
 ENV TZ="$TZ"
 
-# Install basic development tools, Docker CLI, and database tools
-RUN apt update && apt install -y less \
-  git \
-  procps \
-  sudo \
-  fzf \
-  zsh \
-  man-db \
-  unzip \
-  gnupg2 \
-  gh \
-  iproute2 \
-  dnsutils \
-  aggregate \
-  jq \
-  netcat-openbsd \
-  ca-certificates \
-  curl \
-  wget \
-  docker.io \
-  postgresql-client \
-  redis-tools
-
-# Create node user (since we're not using the node base image)
-RUN id -u node >/dev/null 2>&1 || \
-    (groupadd node && useradd --shell /bin/bash --create-home node --gid node)
-
-# Install Node.js via nvm
-ENV NVM_DIR=/usr/local/nvm
-ENV NODE_VERSION=20.18.0
-RUN mkdir -p $NVM_DIR && \
-  curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.0/install.sh | NVM_DIR=$NVM_DIR bash && \
-  . $NVM_DIR/nvm.sh && \
-  nvm install $NODE_VERSION && \
-  nvm alias default $NODE_VERSION && \
-  nvm use default
-
-# Add Node.js to PATH for all users
-ENV PATH=$NVM_DIR/versions/node/v$NODE_VERSION/bin:$PATH
-
-# Install Rust development environment
-RUN apt update && apt install -y \
-  curl \
-  tree \
-  build-essential \
-  pkg-config \
-  libssl-dev \
-  lldb \
-  lld \
-  clang && \
-  curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable && \
-  . $HOME/.cargo/env && \
-  rustup component add rustfmt clippy rust-analyzer
-
-# Add Rust to PATH for all users
-# Note: rustup installs to /root; we export it for subsequent layers/commands.
-ENV PATH="/root/.cargo/bin:${PATH}"
-
-# Ensure default node user has access to /usr/local/share
-RUN mkdir -p /usr/local/share/npm-global && \
-  chown -R node:node /usr/local/share
-
 ARG USERNAME=node
-
-# Persist bash history.
-RUN SNIPPET="export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-  && mkdir /commandhistory \
-  && touch /commandhistory/.bash_history \
-  && chown -R $USERNAME /commandhistory
-
-# Install toolman client globally using installer
-RUN curl --proto '=https' --tlsv1.2 -LsSf \
-    https://github.com/5dlabs/toolman/releases/download/v2.4.4/toolman-installer.sh | \
-    TOOLMAN_NO_MODIFY_PATH=1 sh && \
-    mv ~/.cargo/bin/toolman-client /usr/local/bin/toolman
-
-# Set `DEVCONTAINER` environment variable to help with orientation
 ENV DEVCONTAINER=true
-
-# Create workspace and config directories and set permissions
 RUN mkdir -p /workspace /home/node/.cursor && \
   chown -R node:node /workspace /home/node/.cursor
-
 WORKDIR /workspace
-
-# Install git delta for better diffs
-RUN ARCH=$(dpkg --print-architecture) && \
-  wget "https://github.com/dandavison/delta/releases/download/0.18.2/git-delta_0.18.2_${ARCH}.deb" && \
-  sudo dpkg -i "git-delta_0.18.2_${ARCH}.deb" && \
-  rm "git-delta_0.18.2_${ARCH}.deb"
 
 # Install Cursor CLI (as root), then place binary in /usr/local/bin for all users
 RUN set -eux; \
@@ -104,29 +20,7 @@ RUN set -eux; \
   command -v cursor-agent; \
   cursor-agent --help >/dev/null 2>&1 || true
 
-# Set up non-root user
 USER node
-
-# Install Rust for node user
-RUN curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable && \
-  . $HOME/.cargo/env && \
-  rustup component add rustfmt clippy rust-analyzer
-
-# Global packages PATH and cargo for node user
-ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
-ENV PATH=$PATH:/usr/local/share/npm-global/bin:/home/node/.cargo/bin
-
-# Set the default shell to zsh rather than sh
-ENV SHELL=/bin/zsh
-
-# Default powerline10k theme
-RUN sh -c "$(wget -O- https://github.com/deluan/zsh-in-docker/releases/download/v1.2.0/zsh-in-docker.sh)" -- \
-  -p git \
-  -p fzf \
-  -a "source /usr/share/doc/fzf/examples/key-bindings.zsh" \
-  -a "source /usr/share/doc/fzf/examples/completion.zsh" \
-  -a "export PROMPT_COMMAND='history -a' && export HISTFILE=/commandhistory/.bash_history" \
-  -x
 
 # Cursor CLI is now available via `cursor-agent`
 

--- a/infra/images/gemini-agent/Dockerfile
+++ b/infra/images/gemini-agent/Dockerfile
@@ -1,0 +1,29 @@
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
+
+# Extra utilities Gemini image expects beyond the base
+USER root
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    rsync \
+    ripgrep \
+    psmisc \
+    lsof \
+    socat \
+    bc \
+  && rm -rf /var/lib/apt/lists/*
+
+# Switch back to non-root node user provided by base image
+USER node
+ENV NPM_CONFIG_PREFIX=/usr/local/share/npm-global
+ENV PATH=$PATH:/usr/local/share/npm-global/bin
+
+# Install Gemini CLI from npm (version is provided at build time)
+ARG CLI_VERSION=latest
+RUN npm install -g @google/gemini-cli@${CLI_VERSION} \
+  && npm cache clean --force
+
+# Default entrypoint
+CMD ["gemini"]
+
+

--- a/infra/images/gemini-agent/Dockerfile
+++ b/infra/images/gemini-agent/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ghcr.io/5dlabs/cto/agent-runtime-base:latest
 FROM ${BASE_IMAGE}
 
 # Extra utilities Gemini image expects beyond the base

--- a/infra/images/grok-agent/Dockerfile
+++ b/infra/images/grok-agent/Dockerfile
@@ -1,4 +1,4 @@
-ARG BASE_IMAGE
+ARG BASE_IMAGE=ghcr.io/5dlabs/cto/agent-runtime-base:latest
 FROM ${BASE_IMAGE}
 
 # Ensure working directories exist (base image sets /workspace and user=node)

--- a/infra/images/grok-agent/Dockerfile
+++ b/infra/images/grok-agent/Dockerfile
@@ -1,22 +1,18 @@
-FROM node:18-alpine
+ARG BASE_IMAGE
+FROM ${BASE_IMAGE}
 
-# Install git and other required tools
-RUN apk add --no-cache git openssh-client bash curl jq
-
-# Set working directory
+# Ensure working directories exist (base image sets /workspace and user=node)
+USER node
 WORKDIR /workspace
 
 # Install Grok CLI globally
 RUN npm install -g @vibe-kit/grok-cli
 
-# Create directory for project files
-RUN mkdir -p /workspace/project
-
 # Copy any custom Grok configuration scripts
-COPY scripts/ /workspace/scripts/
+COPY --chown=node:node scripts/ /workspace/scripts/
 RUN chmod +x /workspace/scripts/*.sh
 
-# Set environment variables
+# Environment
 ENV NODE_ENV=production
 ENV GROK_API_KEY=""
 

--- a/infra/images/openhands-agent/Dockerfile
+++ b/infra/images/openhands-agent/Dockerfile
@@ -1,30 +1,22 @@
 ARG BASE_IMAGE=ghcr.io/5dlabs/cto/agent-runtime-base:latest
 FROM ${BASE_IMAGE}
 
+# Install Python and OpenHands CLI
 USER root
-
-# OpenHands is a Python CLI; install Python and pip
 RUN apt-get update && apt-get install -y --no-install-recommends \
     python3 \
     python3-pip \
-    python3-venv \
   && rm -rf /var/lib/apt/lists/*
 
-USER node
+RUN pip3 install --no-cache-dir --upgrade pip && \
+    pip3 install --no-cache-dir openhands-ai
 
+# Drop privileges back to non-root user provided by base image
+USER node
 WORKDIR /workspace
 
-# Install OpenHands CLI from PyPI
-ARG OPENHANDS_VERSION=latest
-RUN python3 -m pip install --no-cache-dir --upgrade pip && \
-    if [ "${OPENHANDS_VERSION}" = "latest" ] || [ -z "${OPENHANDS_VERSION}" ]; then \
-      python3 -m pip install --no-cache-dir openhands-ai; \
-    else \
-      python3 -m pip install --no-cache-dir openhands-ai==${OPENHANDS_VERSION}; \
-    fi
-
-# Default working dir for tasks
-WORKDIR /workspace/project
+# Default entrypoint (can be overridden)
+CMD ["openhands", "--help"]
 
 FROM ubuntu:24.04
 

--- a/infra/images/openhands-agent/Dockerfile
+++ b/infra/images/openhands-agent/Dockerfile
@@ -1,3 +1,31 @@
+ARG BASE_IMAGE=ghcr.io/5dlabs/cto/agent-runtime-base:latest
+FROM ${BASE_IMAGE}
+
+USER root
+
+# OpenHands is a Python CLI; install Python and pip
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    python3 \
+    python3-pip \
+    python3-venv \
+  && rm -rf /var/lib/apt/lists/*
+
+USER node
+
+WORKDIR /workspace
+
+# Install OpenHands CLI from PyPI
+ARG OPENHANDS_VERSION=latest
+RUN python3 -m pip install --no-cache-dir --upgrade pip && \
+    if [ "${OPENHANDS_VERSION}" = "latest" ] || [ -z "${OPENHANDS_VERSION}" ]; then \
+      python3 -m pip install --no-cache-dir openhands-ai; \
+    else \
+      python3 -m pip install --no-cache-dir openhands-ai==${OPENHANDS_VERSION}; \
+    fi
+
+# Default working dir for tasks
+WORKDIR /workspace/project
+
 FROM ubuntu:24.04
 
 ARG TZ


### PR DESCRIPTION
- **feat(agent-runtime): add shared agent runtime base image and migrate Grok to use it\n\n- New base: infra/images/agent-runtime-base (Ubuntu 24.04 + Node 20 + Rust + devtools + toolman)\n- Grok: switch to FROM base and keep Grok CLI install\n- CI: build base first; pass BASE_IMAGE to Grok build**
- **feat(agent-runtime): move Claude image to shared base and wire CI BASE_IMAGE**
- **ci(agents): rebuild dependent agent images when base image was rebuilt**
- **feat(agent-runtime): add gemini-agent image and migrate cursor to shared base; wire CI for both**
- **ci: disable GHA cache export and rebuild when base changes to fix Buildx docker driver cache errors**
- **ci: trigger on all branches and workflow changes; disable cache export in remaining jobs**
- **ci: enable multi-arch by adding QEMU and ensuring Buildx is set up for all agent builds (fix docker driver multi-platform error)**
- **images: set sane default BASE_IMAGE (latest) in Dockerfiles; CI still injects pinned v<hash> tag output from base job**
- **cursor-agent: install CLI as root then drop to node; add manual Cursor test workflow (amd64, BASE_IMAGE input)**
- **workflows: add manual test builds for Claude Code and Grok (amd64, BASE_IMAGE input)**
- **feat(agents): add OpenHands image and manual test workflows for Gemini and OpenHands**
- **feat(images): add OpenHands agent image; add manual test workflows for Gemini and OpenHands**
- **ci: trigger Agent Images workflow (no-op change)**
- **ci: include OpenHands and Gemini agent jobs in main workflow; depend on base and pin BASE_IMAGE; update summary**
