### PR TITLE
Hotfix: Fix Redis operator version to resolve sync error

### DIFF
--- a/infra/gitops/applications/redis-operator.yaml
+++ b/infra/gitops/applications/redis-operator.yaml
@@ -21,7 +21,7 @@ spec:
   # Source configuration - Using Spotahome's manifests
   source:
     repoURL: https://github.com/spotahome/redis-operator
-    targetRevision: v1.3.0  # Latest stable version
+    targetRevision: v1.3.0-rc1  # Latest available version (stable v1.3.0 not yet released)
     path: manifests
 
     # Kustomize configuration to deploy the operator


### PR DESCRIPTION
## Issue
Redis operator failing with: `unable to resolve 'v1.3.0' to a commit SHA`

## Root Cause
The stable `v1.3.0` release doesn't exist in `spotahome/redis-operator` repository - only `v1.3.0-rc1` (release candidate) is available.

## Fix
- Change `targetRevision` from `v1.3.0` → `v1.3.0-rc1`
- This resolves the sync error and allows Redis operator to deploy

## Verification
- [x] Redis operator sync error resolved
- [x] Uses latest available version from upstream

🤖 Generated with [Claude Code](https://claude.ai/code)