### PR TITLE
Fix Redis operator kustomize error - use raw manifests

### DIFF
--- a/infra/gitops/applications/redis-operator.yaml
+++ b/infra/gitops/applications/redis-operator.yaml
@@ -24,14 +24,10 @@ spec:
     targetRevision: v1.3.0-rc1  # Latest available version (stable v1.3.0 not yet released)
     path: manifests
 
-    # Kustomize configuration to deploy the operator
-    kustomize:
-      namespace: redis-operator
-
-      # Optional: Add resource customizations
-      commonLabels:
-        app.kubernetes.io/managed-by: argocd
-        app.kubernetes.io/part-of: platform
+    # Directory configuration - use raw manifests without kustomize
+    directory:
+      recurse: false
+      include: "*.yaml"
 
   # Destination configuration
   destination:


### PR DESCRIPTION
## Problem
Redis operator fails to sync with error:
```
Failed to load target state: failed to generate manifest for source 1 of 1: rpc error: code = Unknown desc = `kustomize edit add label` failed exit status 1: Error: Missing kustomization file 'kustomization.yaml'
```

## Root Cause
The `spotahome/redis-operator` repository doesn't have a `kustomization.yaml` file in the `manifests/` directory, but our ArgoCD application is trying to use kustomize configuration.

## Solution
- Remove `kustomize` configuration from the source
- Use `directory` source type instead to deploy raw YAML manifests
- This matches how the upstream repository is intended to be used

## Testing
- [x] Redis operator now syncs successfully in ArgoCD
- [x] Operator deployment is healthy
- [x] No more kustomize-related errors

## Impact
This ensures that when ArgoCD syncs from main branch, it won't undo the working Redis operator configuration.

🤖 Generated with [Claude Code](https://claude.ai/code)