### PR TITLE
Fix database instances CRD validation errors

### DIFF
--- a/infra/gitops/databases/agent-docs-postgres.yaml
+++ b/infra/gitops/databases/agent-docs-postgres.yaml
@@ -107,34 +107,23 @@ spec:
     agent_docs_db:
       defaultUsers: true
       extensions:
-        pg_stat_statements:
-          schema: "public"
-        pgcrypto:
-          schema: "public"
-        uuid-ossp:
-          schema: "public"
-        pg_trgm:           # For full-text search
-          schema: "public"
-        hstore:            # For key-value storage
-          schema: "public"
-        pgvector:          # For vector embeddings (AI/ML)
-          schema: "public"
+        pg_stat_statements: "public"
+        pgcrypto: "public"
+        uuid-ossp: "public"
+        pg_trgm: "public"           # For full-text search
+        hstore: "public"            # For key-value storage
+        pgvector: "public"          # For vector embeddings (AI/ML)
     agent_tasks_db:
       defaultUsers: true
       extensions:
-        pg_stat_statements:
-          schema: "public"
-        uuid-ossp:
-          schema: "public"
-        pgvector:          # For semantic task search
-          schema: "public"
+        pg_stat_statements: "public"
+        uuid-ossp: "public"
+        pgvector: "public"          # For semantic task search
     agent_metrics_db:
       defaultUsers: true
       extensions:
-        pg_stat_statements:
-          schema: "public"
-        timescaledb:       # For time-series metrics (if available)
-          schema: "public"
+        pg_stat_statements: "public"
+        timescaledb: "public"       # For time-series metrics (if available)
 
   # Connection pooler for handling multiple agent connections
   enableConnectionPooler: true
@@ -175,7 +164,7 @@ spec:
 
   # Maintenance windows (UTC)
   maintenanceWindows:
-    - everyday: 03:00-04:00
+    - "03:00-04:00"
 
 ---
 # Service for agent-docs to connect via pooler

--- a/infra/gitops/databases/agent-docs-questdb.yaml
+++ b/infra/gitops/databases/agent-docs-questdb.yaml
@@ -15,10 +15,7 @@ metadata:
     app.kubernetes.io/part-of: agent-platform
 spec:
   # QuestDB image configuration
-  image:
-    repository: questdb/questdb
-    tag: "7.3.10"  # Latest stable version
-    pullPolicy: IfNotPresent
+  image: "questdb/questdb:7.3.10"  # Latest stable version
 
   # Volume configuration for data persistence
   volume:


### PR DESCRIPTION
## Problem
Database instances failing ArgoCD sync with CRD validation errors:

**PostgreSQL errors:**
```
spec.preparedDatabases.agent_docs_db.extensions.pgvector: Invalid value: "object": must be of type string: "object"
spec.maintenanceWindows[0]: Invalid value: "object": must be of type string: "object"
```

**QuestDB error:**
```
admission webhook denied the request: json: cannot unmarshal object into Go struct field QuestDBSpec.spec.image of type string
```

## Root Cause
Database CRD schemas expect string values, but we were providing object configurations:
- PostgreSQL extensions: `pgvector: {schema: "public"}` instead of `pgvector: "public"`
- PostgreSQL maintenance: `{everyday: "03:00-04:00"}` instead of `"03:00-04:00"`
- QuestDB image: `{repository, tag, pullPolicy}` instead of `"questdb/questdb:7.3.10"`

## Solution
- **PostgreSQL**: Change extensions to string format (schema name as value)
- **PostgreSQL**: Change maintenance windows to string format  
- **QuestDB**: Change image to simple string format

## Testing
- [x] Fixed PostgreSQL CRD validation for extensions and maintenance windows
- [x] Fixed QuestDB CRD validation for image field
- [x] Database instances should now sync successfully in ArgoCD

🤖 Generated with [Claude Code](https://claude.ai/code)