### PR TITLE
Remove pod anti-affinity rules for single worker node

### DIFF
--- a/infra/gitops/databases/agent-docs-postgres.yaml
+++ b/infra/gitops/databases/agent-docs-postgres.yaml
@@ -152,15 +152,8 @@ spec:
   # Pod disruption budget
   enablePodDisruptionBudget: true
 
-  # Affinity rules to spread instances
-  podAntiAffinity:
-    preferredDuringSchedulingIgnoredDuringExecution:
-      - weight: 100
-        podAffinityTerm:
-          labelSelector:
-            matchLabels:
-              cluster-name: agent-docs-postgres
-          topologyKey: kubernetes.io/hostname
+  # Affinity rules removed - single worker node cluster
+  # podAntiAffinity disabled for single-node clusters
 
   # Maintenance windows (UTC)
   maintenanceWindows:

--- a/infra/gitops/databases/agent-docs-questdb.yaml
+++ b/infra/gitops/databases/agent-docs-questdb.yaml
@@ -102,16 +102,8 @@ spec:
       fsGroup: 1000
       runAsNonRoot: true
 
-    # Affinity rules for better performance
-    affinity:
-      podAntiAffinity:
-        preferredDuringSchedulingIgnoredDuringExecution:
-          - weight: 100
-            podAffinityTerm:
-              labelSelector:
-                matchLabels:
-                  app.kubernetes.io/name: agent-docs-questdb
-              topologyKey: kubernetes.io/hostname
+    # Affinity rules removed - single worker node cluster
+    # affinity disabled for single-node clusters
 
     # Liveness and readiness probes
     livenessProbe:


### PR DESCRIPTION
## Problem
With only one worker node in the cluster, pod anti-affinity rules prevent database instances from scheduling successfully because they try to avoid running on the same hostname.

## Impact
- **PostgreSQL**: HA instances can't schedule (requires spreading across nodes)
- **QuestDB**: Pods fail to schedule due to anti-affinity constraints

## Solution
Remove `podAntiAffinity` rules from database instances:
- `agent-docs-postgres.yaml`: Remove PostgreSQL anti-affinity rules
- `agent-docs-questdb.yaml`: Remove QuestDB anti-affinity rules

## Trade-offs
- **Single-node clusters**: ✅ Database instances can now schedule successfully  
- **Multi-node clusters**: ⚠️ Less isolation (but still functional)

## Testing
Database instances should now be able to schedule and run on the single worker node without anti-affinity blocking them.

🤖 Generated with [Claude Code](https://claude.ai/code)