### PR TITLE
Fix QuestDB operator health check causing App of Apps sync issues

### DIFF
--- a/infra/gitops/applications/questdb-operator.yaml
+++ b/infra/gitops/applications/questdb-operator.yaml
@@ -93,12 +93,5 @@ spec:
       jsonPointers:
         - /webhooks/0/clientConfig/caBundle
 
-  # Health assessment
-  health:
-    - group: apps
-      kind: Deployment
-      namespace: questdb-operator
-      name: questdb-operator-controller-manager
-
   # Revision history
   revisionHistoryLimit: 5


### PR DESCRIPTION
## Problem

The App of Apps (platform-apps) shows OutOfSync status despite all individual applications being Synced and Healthy. Investigation revealed this is caused by a custom health check configuration in the QuestDB operator application.

## Root Cause

Custom health checks in ArgoCD applications can cause sync conflicts and are often unnecessary since ArgoCD automatically manages application health assessment.

## Solution

- Remove the problematic custom health check from questdb-operator Application
- ArgoCD will continue to automatically assess the QuestDB operator deployment health
- This resolves the App of Apps OutOfSync issue

## Verification

After this change:
- QuestDB operator will remain fully functional
- App of Apps should show Synced status
- All database operations continue normally

## Files Changed

- : Removed custom health check section

🤖 Generated with [Claude Code](https://claude.ai/code)