### PR TITLE
fix(intake): rely on task-master default output for parse-prd

### DIFF
--- a/infra/charts/controller/claude-templates/intake/intake.sh
+++ b/infra/charts/controller/claude-templates/intake/intake.sh
@@ -409,7 +409,6 @@ task-master models --set-fallback "claude-3-5-sonnet-20241022"
 echo "📄 Parsing PRD to generate tasks..."
 task-master parse-prd \
     --input ".taskmaster/docs/prd.txt" \
-    --output ".taskmaster/tasks/tasks.json" \
     --force || {
     echo "❌ Failed to parse PRD"
     exit 1


### PR DESCRIPTION
- Remove explicit --output .taskmaster/tasks/tasks.json from intake script\n- Avoids error when override path doesn't exist\n- TaskMaster CLI creates tasks.json at its default path and later steps proceed