### PR TITLE
fix(intake): align Claude CLI flags (-p, --verbose, stream-json)

### DIFF
--- a/infra/charts/controller/claude-templates/intake/intake.sh
+++ b/infra/charts/controller/claude-templates/intake/intake.sh
@@ -478,7 +478,7 @@ EOF
 
         # Run Claude to review and update tasks
         echo "🔍 Running Claude review..."
-        claude --output-format stream-json --model "$MODEL" /tmp/review-prompt.md || {
+        claude -p --output-format stream-json --verbose --model "$MODEL" /tmp/review-prompt.md || {
             echo "⚠️ Claude review failed, but continuing..."
         }
         


### PR DESCRIPTION
Use same Claude CLI flags as code/docs templates to avoid stream-json/verbose error.\n\n- claude -p --output-format stream-json --verbose --model "" /tmp/review-prompt.md\n- Scope: intake container script only