### PR TITLE
fix(docs): prevent FIFO hang; add input-bridge sidecar to DocsRun when enabled

### DIFF
--- a/infra/charts/controller/claude-templates/docs/container.sh.hbs
+++ b/infra/charts/controller/claude-templates/docs/container.sh.hbs
@@ -440,14 +440,16 @@ SAFE_MODE="false"  # Set to "false" for full docs generation
       FIFO_PATH="/workspace/agent-input.jsonl"
       rm -f "$FIFO_PATH" 2>/dev/null || true
       mkfifo "$FIFO_PATH"
-      # Keep a persistent writer open to avoid EOF
+      # Start Claude in background, send initial message, then close writer so it can exit
       exec 9>"$FIFO_PATH"
       if [ -f "prompt.md" ]; then
-          # Initial user turn from prompt.md only; system prompts are set via CLI flags, not streamed
           INITIAL_TEXT=$(jq -Rs . < "prompt.md")
+          $CLAUDE_CMD < "$FIFO_PATH" &
+          CLAUDE_PID=$!
           printf '{"type":"user","message":{"role":"user","content":[{"type":"text","text":%s}]}}\n' "$INITIAL_TEXT" >&9
-          # Start Claude reading from FIFO (fd 9 stays open)
-          $CLAUDE_CMD < "$FIFO_PATH"
+          # Close writer so Claude receives EOF after processing and exits
+          exec 9>&-
+          wait $CLAUDE_PID
           CLAUDE_EXIT_CODE=$?
           echo "Claude completed with exit code: $CLAUDE_EXIT_CODE"
       else

--- a/infra/charts/controller/values.yaml
+++ b/infra/charts/controller/values.yaml
@@ -19,7 +19,7 @@ agent:
   
   # Input bridge sidecar configuration for live input to running jobs
   inputBridge:
-    enabled: false
+    enabled: true
     image:
       repository: ghcr.io/5dlabs/cto/input-bridge
       tag: "latest"


### PR DESCRIPTION
Summary\n- Prevent docs job hang by starting Claude in background, writing initial user turn to FIFO via persistent fd 9, then closing the writer and waiting.\n- Add input-bridge sidecar for DocsRun jobs when agent.inputBridge.enabled is true, using configured image and port; create/update headless Service for discovery.\n\nDetails\n- Files\n  - infra/charts/controller/claude-templates/docs/container.sh.hbs\n  - controller/src/tasks/docs/resources.rs\n- Sidecar uses env FIFO_PATH=/workspace/agent-input.jsonl and PORT from config.\n- Headless Service: <job-name>-bridge with agents.platform/* labels for discovery.\n\nConfig\n- Enable in chart values: agent.inputBridge.enabled=true and set agent.inputBridge.image.repository/tag and port.\n\nTest Plan\n1) Apply controller with inputBridge enabled and image configured.\n2) Submit a DocsRun. Verify pod has containers: [claude-docs, input-bridge].\n3) Confirm Service <job-name>-bridge exists (clusterIP None).\n4) Verify docs job completes (no hang).\n\nNotes\n- Aligns with code agent behavior and fixes safe-mode race by persisting FIFO writer and ordering start/write/close.