### PR TITLE
fix(containers): relax FIFO permissions for input-bridge bring-up

### DIFF
--- a/infra/charts/controller/claude-templates/code/container.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container.sh.hbs
@@ -912,6 +912,7 @@ if [ "$SAFE_MODE" = "true" ]; then
     FIFO_PATH="/workspace/agent-input.jsonl"
     rm -f "$FIFO_PATH" 2>/dev/null || true
     mkfifo "$FIFO_PATH"
+    chmod 666 "$FIFO_PATH" || true
     # Keep a persistent writer open and start Claude in background to avoid EOF race
     exec 9>"$FIFO_PATH"
     $CLAUDE_CMD < "$FIFO_PATH" &
@@ -972,6 +973,7 @@ Before starting implementation, you MUST read and follow the task-specific tool 
         FIFO_PATH="/workspace/agent-input.jsonl"
         rm -f "$FIFO_PATH" 2>/dev/null || true
         mkfifo "$FIFO_PATH"
+        chmod 666 "$FIFO_PATH" || true
         # Keep a persistent writer open to avoid EOF on reader
         exec 9>"$FIFO_PATH"
 

--- a/infra/charts/controller/claude-templates/docs/container.sh.hbs
+++ b/infra/charts/controller/claude-templates/docs/container.sh.hbs
@@ -440,14 +440,16 @@ SAFE_MODE="false"  # Set to "false" for full docs generation
       FIFO_PATH="/workspace/agent-input.jsonl"
       rm -f "$FIFO_PATH" 2>/dev/null || true
       mkfifo "$FIFO_PATH"
-      # Keep a persistent writer open to avoid EOF
+      # Start Claude in background, send initial message, then close writer so it can exit
       exec 9>"$FIFO_PATH"
       if [ -f "prompt.md" ]; then
-          # Initial user turn from prompt.md only; system prompts are set via CLI flags, not streamed
           INITIAL_TEXT=$(jq -Rs . < "prompt.md")
+          $CLAUDE_CMD < "$FIFO_PATH" &
+          CLAUDE_PID=$!
           printf '{"type":"user","message":{"role":"user","content":[{"type":"text","text":%s}]}}\n' "$INITIAL_TEXT" >&9
-          # Start Claude reading from FIFO (fd 9 stays open)
-          $CLAUDE_CMD < "$FIFO_PATH"
+          # Close writer so Claude receives EOF after processing and exits
+          exec 9>&-
+          wait $CLAUDE_PID
           CLAUDE_EXIT_CODE=$?
           echo "Claude completed with exit code: $CLAUDE_EXIT_CODE"
       else

--- a/infra/charts/controller/claude-templates/docs/container.sh.hbs
+++ b/infra/charts/controller/claude-templates/docs/container.sh.hbs
@@ -422,6 +422,7 @@ SAFE_MODE="false"  # Set to "false" for full docs generation
       FIFO_PATH="/workspace/agent-input.jsonl"
       rm -f "$FIFO_PATH" 2>/dev/null || true
       mkfifo "$FIFO_PATH"
+      chmod 666 "$FIFO_PATH" || true
       # Keep a persistent writer open; start Claude in background, then send one message and close
       exec 9>"$FIFO_PATH"
       $CLAUDE_CMD < "$FIFO_PATH" &
@@ -440,6 +441,7 @@ SAFE_MODE="false"  # Set to "false" for full docs generation
       FIFO_PATH="/workspace/agent-input.jsonl"
       rm -f "$FIFO_PATH" 2>/dev/null || true
       mkfifo "$FIFO_PATH"
+      chmod 666 "$FIFO_PATH" || true
       # Start Claude in background, send initial message, then close writer so it can exit
       exec 9>"$FIFO_PATH"
       if [ -f "prompt.md" ]; then

--- a/infra/charts/controller/values.yaml
+++ b/infra/charts/controller/values.yaml
@@ -19,7 +19,7 @@ agent:
   
   # Input bridge sidecar configuration for live input to running jobs
   inputBridge:
-    enabled: false
+    enabled: true
     image:
       repository: ghcr.io/5dlabs/cto/input-bridge
       tag: "latest"


### PR DESCRIPTION
Summary\n- Set permissive FIFO perms (chmod 666) after mkfifo in both code/docs container templates.\n- Resolves input-bridge PermissionDenied (EACCES) when sidecar runs as non-root before securityContexts are aligned.\n\nFiles\n- infra/charts/controller/claude-templates/code/container.sh.hbs\n- infra/charts/controller/claude-templates/docs/container.sh.hbs\n\nNotes\n- Temporary for bring-up; we can tighten to fsGroup+chmod 660 later.\n- No binary changes; templates only.\n\nTest Plan\n- Submit CodeRun/DocsRun; verify sidecar opens FIFO and job no longer hangs.\n- Confirm /input responds 200 and Claude processes message.