### PR TITLE
feat(controller): align Job pod securityContext with STS for workspace access

### DIFF
--- a/controller/src/tasks/code/resources.rs
+++ b/controller/src/tasks/code/resources.rs
@@ -739,6 +739,12 @@ impl<'a> CodeResourceManager<'a> {
                     },
                     "spec": {
                         "restartPolicy": "Never",
+                        "securityContext": {
+                            "runAsUser": 1000,
+                            "runAsGroup": 1000,
+                            "fsGroup": 1000,
+                            "fsGroupChangePolicy": "OnRootMismatch"
+                        },
                         "containers": containers,
                         "volumes": volumes
                     }

--- a/controller/src/tasks/docs/resources.rs
+++ b/controller/src/tasks/docs/resources.rs
@@ -683,6 +683,12 @@ impl<'a> DocsResourceManager<'a> {
                     },
                     "spec": {
                         "restartPolicy": "Never",
+                        "securityContext": {
+                            "runAsUser": 1000,
+                            "runAsGroup": 1000,
+                            "fsGroup": 1000,
+                            "fsGroupChangePolicy": "OnRootMismatch"
+                        },
                         "containers": containers,
                         "volumes": volumes
                     }


### PR DESCRIPTION
Summary\n- Add pod-level securityContext to CodeRun and DocsRun Jobs: runAsUser:1000, runAsGroup:1000, fsGroup:1000, fsGroupChangePolicy: OnRootMismatch.\n- Mirrors StatefulSet behavior where workspace access is known-good.\n\nRationale\n- Ensures sidecar (input-bridge) and main container share GID-based access to /workspace and FIFO without relying on world-writable perms.\n- Complements existing FIFO creation and retry logic.\n\nFiles\n- controller/src/tasks/code/resources.rs\n- controller/src/tasks/docs/resources.rs\n\nTest Plan\n- Deploy controller; submit CodeRun and DocsRun; verify pod spec includes securityContext at pod level, both containers run as uid/gid 1000.\n- Confirm input-bridge opens FIFO and messages flow.\n\nNotes\n- No change to container images; controller update only.\n