### PR TITLE
feat(argocd): enable auto-sync/self-heal with fast backoff

### DIFF
--- a/infra/gitops/app-of-apps.yaml
+++ b/infra/gitops/app-of-apps.yaml
@@ -35,11 +35,10 @@ spec:
 
   # Sync policy
   syncPolicy:
-    # TEMPORARILY DISABLED: Auto sync disabled for manual control during fixes
-    # automated:
-    #   prune: true
-    #   selfHeal: true
-    #   allowEmpty: false
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
 
     syncOptions:
       - CreateNamespace=true
@@ -49,7 +48,7 @@ spec:
     retry:
       limit: 5
       backoff:
-        duration: 5s
+        duration: 1s
         factor: 2
         maxDuration: 3m
 

--- a/infra/gitops/applications/controller.yaml
+++ b/infra/gitops/applications/controller.yaml
@@ -64,11 +64,10 @@ spec:
 
   # Sync policy
   syncPolicy:
-    # TEMPORARILY DISABLED: Auto sync disabled for manual control during fixes
-    # automated:
-    #   prune: true
-    #   selfHeal: true
-    #   allowEmpty: false
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
 
     syncOptions:
       - CreateNamespace=true
@@ -80,7 +79,7 @@ spec:
     retry:
       limit: 5
       backoff:
-        duration: 5s
+        duration: 1s
         factor: 2
         maxDuration: 3m
 


### PR DESCRIPTION
- Enable automated sync (prune + selfHeal + allowEmpty)\n- Reduce retry backoff to 1s for quicker reconciliation\n- Applied to: app-of-apps and controller Applications\n\nIf you want this on all apps, I can replicate across remaining Application manifests.