### PR TITLE
Allow Fluent Bit Helm repo in platform AppProject

### DIFF
--- a/infra/gitops/projects/platform-project.yaml
+++ b/infra/gitops/projects/platform-project.yaml
@@ -24,6 +24,7 @@ spec:
     - 'https://5dlabs.github.io/cto'
     - 'https://github.com/5dlabs/*'
     - 'https://argoproj.github.io/argo-helm'
+    - 'https://fluent.github.io/helm-charts'
     - 'https://prometheus-community.github.io/helm-charts'
     - 'https://grafana.github.io/helm-charts'
     - 'https://open-telemetry.github.io/opentelemetry-helm-charts'


### PR DESCRIPTION
Fixes Argo CD InvalidSpecError for `fluent-bit` Application:

InvalidSpecError: application repo https://fluent.github.io/helm-charts is not permitted in project 'platform'

Changes:
- Add `https://fluent.github.io/helm-charts` to `spec.sourceRepos` in `infra/gitops/projects/platform-project.yaml`.

Notes:
- This unblocks the `infra/gitops/applications/fluent-bit.yaml` Application which sources the `fluent-bit` chart from the Fluent Helm repo.
- No other changes required; destinations already include `telemetry` namespace.

Once merged to `main`, Argo CD should sync the Fluent Bit app successfully. [[memory:5806097]][[memory:6133257]]