### PR TITLE
argocd: allow Fluent Bit Helm repo in platform AppProject (fix InvalidSpecError for fluent-bit app) (#173)

### DIFF
--- a/infra/gitops/applications/fluent-bit.yaml
+++ b/infra/gitops/applications/fluent-bit.yaml
@@ -108,4 +108,6 @@ spec:
       selfHeal: true
     syncOptions:
       - CreateNamespace=true
+      - Replace=true
+      - PrunePropagationPolicy=foreground
 


### PR DESCRIPTION
Co-authored-by: Jonathon Fritz <j@jonathonfritz.com>