### PR TITLE
Manage telemetry namespace PSA to allow Fluent Bit hostPath volumes

### DIFF
--- a/infra/cluster-config/telemetry-namespace.yaml
+++ b/infra/cluster-config/telemetry-namespace.yaml
@@ -1,0 +1,14 @@
+---
+# Managed Namespace for telemetry with Pod Security labels allowing hostPath
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: telemetry
+  labels:
+    pod-security.kubernetes.io/enforce: privileged
+    pod-security.kubernetes.io/enforce-version: latest
+    pod-security.kubernetes.io/warn: privileged
+    pod-security.kubernetes.io/warn-version: latest
+    pod-security.kubernetes.io/audit: privileged
+    pod-security.kubernetes.io/audit-version: latest
+

--- a/infra/gitops/applications/telemetry-namespace.yaml
+++ b/infra/gitops/applications/telemetry-namespace.yaml
@@ -1,0 +1,31 @@
+---
+# Argo CD Application to manage telemetry Namespace labels (PSA)
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: telemetry-namespace
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: telemetry-namespace
+    app.kubernetes.io/part-of: platform
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/5dlabs/cto
+    targetRevision: main
+    path: infra/cluster-config
+    directory:
+      recurse: false
+      include: telemetry-namespace.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: telemetry
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+


### PR DESCRIPTION
Fix Fluent Bit pod creation failures due to Pod Security Admission baseline policy blocking hostPath volumes.

Error:
- pods are forbidden: violates PodSecurity "baseline:latest": hostPath volumes (volumes "varlog", "varlibdockercontainers", "etcmachineid")

Changes:
- Add `infra/cluster-config/telemetry-namespace.yaml` to manage `telemetry` namespace with privileged PSA labels.
- Add Argo CD Application `infra/gitops/applications/telemetry-namespace.yaml` to apply labels via GitOps.

Notes:
- This permits hostPath volumes required by Fluent Bit.
- `fluent-bit` Application already has Replace=true to handle DS immutability.

Once merged to `main`, Argo CD will label the namespace and Fluent Bit pods should be created successfully. [[memory:6133257]] [[memory:5806097]]