### PR TITLE
RBAC: add nodes read to github-runner-argocd-access (v2)

### DIFF
--- a/infra/gitops/github-runner-rbac.yaml
+++ b/infra/gitops/github-runner-rbac.yaml
@@ -8,7 +8,7 @@ rules:
   resources: ["applications"]
   verbs: ["get", "list", "patch", "update"]
 - apiGroups: [""]
-  resources: ["pods", "services"]
+  resources: ["pods", "services", "nodes"]
   verbs: ["get", "list", "watch"]
 - apiGroups: ["apps"]
   resources: ["deployments", "replicasets"]


### PR DESCRIPTION
Add read-only access to core nodes in infra/gitops/github-runner-rbac.yaml so ARC runners can run kubectl cluster-info and kubectl get nodes. YAML lint passes.\n\n- ClusterRole github-runner-argocd-access: include nodes in resources with get/list/watch\n- Binding unchanged\n\nAfter merge to main, Argo CD will sync RBAC. We can then remove temporary clusterrolebinding runner-nodes-readonly-binding from the cluster.