### PR TITLE
ArgoCD: permit Gateway API + IngressClass in platform AppProject

### DIFF
--- a/infra/gitops/projects/platform-project.yaml
+++ b/infra/gitops/projects/platform-project.yaml
@@ -102,6 +102,10 @@ spec:
       kind: MutatingWebhookConfiguration
     - group: 'admissionregistration.k8s.io'
       kind: ValidatingWebhookConfiguration
+    - group: 'networking.k8s.io'
+      kind: IngressClass
+    - group: 'gateway.networking.k8s.io'
+      kind: GatewayClass
     - group: 'agents.platform'
       kind: '*'
     - group: 'actions.github.com'
@@ -125,6 +129,8 @@ spec:
     - group: 'extensions'
       kind: '*'
     - group: 'networking.k8s.io'
+      kind: '*'
+    - group: 'gateway.networking.k8s.io'
       kind: '*'
     - group: 'rbac.authorization.k8s.io'
       kind: '*'


### PR DESCRIPTION
- Allow cluster-scoped GatewayClass and IngressClass
- Allow namespaced Gateway/HTTPRoute, fixing sync failures for ngrok-gateway and github-webhooks

After merge, Argo should sync ngrok-operator, ngrok-gateway, and github-webhooks cleanly.