### PR TITLE
Disable demo Sensor (keep code, stop creating pods)

### DIFF
--- a/infra/gitops/resources/github-webhooks/kustomization.yaml
+++ b/infra/gitops/resources/github-webhooks/kustomization.yaml
@@ -5,7 +5,6 @@ resources:
   - httproute.yaml
   - eventsource.yaml
   - eventbus.yaml
-  - sensor.yaml
   - externalsecret.yaml
   - sa-rbac.yaml
 


### PR DESCRIPTION
- Exclude  from 
- Keeps the demo Sensor manifest in repo for reference, but stops it from being applied
- No more demo pods will be created on GitHub org events

Can re-enable later by adding  back to the kustomization.