### PR TITLE
fix(intake): avoid branch prefix collision by using hyphen and sanitized project name

### DIFF
--- a/infra/charts/controller/claude-templates/intake/intake.sh
+++ b/infra/charts/controller/claude-templates/intake/intake.sh
@@ -593,7 +593,9 @@ $([ "$ANALYZE_COMPLEXITY" = "true" ] && echo "- Complexity analysis performed")
 "
 
 # Create branch and push
-BRANCH_NAME="intake/$PROJECT_NAME-$(date +%Y%m%d-%H%M%S)"
+# Use a hyphenated prefix to avoid collisions when a flat ref named 'intake' exists remotely
+# Also prefer the sanitized, lowercase project directory name for the branch component
+BRANCH_NAME="intake-${PROJECT_DIR_NAME}-$(date +%Y%m%d-%H%M%S)"
 echo "🌿 Creating branch: $BRANCH_NAME"
 git checkout -b "$BRANCH_NAME"
 git push -u origin "$BRANCH_NAME"


### PR DESCRIPTION
- Replace branch naming from `intake/-...` to `intake--...` to avoid conflicts when a flat ref `refs/heads/intake` exists.
- Uses sanitized, lowercase `` which is already computed earlier in the script.

This prevents failures like: \n> cannot lock ref 'refs/heads/intake/Docs-YYYYMMDD-HHMMSS': 'refs/heads/intake' exists; cannot create 'refs/heads/intake/Docs-...'

After merge to main and Argo CD rollout, re-run intake for docs.