### PR TITLE
docs: clarify Argo CLI availability and make GitHub App creation mandatory

### DIFF
--- a/docs/.taskmaster/docs/task-1/acceptance-criteria.md
+++ b/docs/.taskmaster/docs/task-1/acceptance-criteria.md
@@ -8,7 +8,8 @@ This document defines the acceptance criteria for implementing Helm values and A
 ### 0. Prerequisites Verification ✓
 - [ ] kubectl access verified (`kubectl cluster-info` works)
 - [ ] Argo CD CLI access verified (`argocd app list` works after login)
-- [ ] GitHub access verified (can create apps via UI or API)
+- [ ] **Argo Workflows CLI access verified** (`argo version --short` works - CLI is at `/usr/local/bin/argo`)
+- [ ] GitHub access verified (can create apps via UI or API using `GITHUB_ADMIN_TOKEN`)
 - [ ] All required environment variables are set and valid
 
 ### 1. Helm Chart Structure ✓
@@ -38,6 +39,7 @@ This document defines the acceptance criteria for implementing Helm values and A
   - [ ] Generated App ID and private key stored in external secret store
 - [ ] **VALIDATION**: Apps must be visible at `https://github.com/organizations/5dlabs/settings/apps`
 - [ ] **VALIDATION**: Each app must be installed on the organization with appropriate repository access
+- [ ] **CRITICAL**: GitHub Apps must be ACTUALLY CREATED during task execution, not left as "next steps"
 
 ### 3. Schema Validation ✓
 - [ ] `values.schema.json` exists and validates structure

--- a/docs/.taskmaster/docs/task-1/task.md
+++ b/docs/.taskmaster/docs/task-1/task.md
@@ -53,9 +53,12 @@ The container template (`infra/charts/controller/claude-templates/code/container
 Before starting implementation, verify access to required tools:
 - **kubectl**: Must have access to the Kubernetes cluster (via `KUBECONFIG_B64` environment variable)
 - **Argo CD CLI**: Must be able to login and sync applications (via `ARGOCD_SERVER`, `ARGOCD_USERNAME`, `ARGOCD_PASSWORD`)
+- **Argo Workflows CLI**: Available at `/usr/local/bin/argo` - test with `argo version --short` (should show v3.7.1+)
 - **GitHub CLI or API access**: For creating GitHub Apps (via `GITHUB_ADMIN_TOKEN`)
 
 If any of these tools are not accessible, STOP and report the issue before proceeding.
+
+**IMPORTANT**: The Argo Workflows CLI (`argo`) is different from Argo CD CLI (`argocd`). Both are available in the container.
 
 ## CRITICAL REQUIREMENT: GitHub App Creation
 
@@ -75,6 +78,8 @@ If any of these tools are not accessible, STOP and report the issue before proce
 - **Validation**: Apps must be visible at `https://github.com/organizations/5dlabs/settings/apps`
 
 **ACCEPTANCE CRITERIA**: The task is NOT complete until all four GitHub Apps are created, installed, and visible in the GitHub organization settings.
+
+**DO NOT** mark this task as complete or create a PR saying "Next Steps: Create GitHub Apps". The GitHub Apps MUST be created as part of the task execution. Use the `GITHUB_ADMIN_TOKEN` environment variable to create them via GitHub CLI or API calls.
 
 ## Implementation Guide
 

--- a/infra/images/runtime/Dockerfile
+++ b/infra/images/runtime/Dockerfile
@@ -119,7 +119,7 @@ RUN --mount=type=cache,target=/tmp/downloads,sharing=locked \
         gunzip -c "/tmp/argo-linux-${DL_ARCH}.gz" > /usr/local/bin/argo && \
         chmod +x /usr/local/bin/argo && \
         rm -f "/tmp/argo-linux-${DL_ARCH}.gz" && \
-        argo version --short --client && break || \
+        argo version --short && break || \
         (echo "Attempt $i failed, retrying..." && sleep 5); \
     done
 


### PR DESCRIPTION
- Add explicit Argo Workflows CLI verification to prerequisites
- Clarify difference between argo (workflows) and argocd (CD) CLIs
- Make GitHub App creation CRITICAL and mandatory during task execution
- Fix Dockerfile to use correct argo version syntax (remove --client flag)
- Prevent agents from marking task complete without creating GitHub Apps