### PR TITLE
Fix MCP linter errors and authentication analysis

### DIFF
--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1402,7 +1402,6 @@ fn handle_send_job_input(arguments: &std::collections::HashMap<String, Value>) -
         .unwrap_or("code");
     let user = arguments.get("user").and_then(|v| v.as_str());
     let service = arguments.get("service").and_then(|v| v.as_str());
-    let task_id = arguments.get("task_id");
 
     // Build service selector based on available parameters
     let mut label_selectors = vec![
@@ -1472,7 +1471,9 @@ fn handle_send_job_input(arguments: &std::collections::HashMap<String, Value>) -
         .send()
         .context("Failed to send HTTP request to input bridge")?;
 
-    if response.status().is_success() {
+    let status = response.status();
+    
+    if status.is_success() {
         let response_text = response.text().unwrap_or_else(|_| "OK".to_string());
         Ok(json!({
             "success": true,
@@ -1484,7 +1485,7 @@ fn handle_send_job_input(arguments: &std::collections::HashMap<String, Value>) -
         let error_text = response.text().unwrap_or_else(|_| "Unknown error".to_string());
         Err(anyhow!(
             "HTTP request failed with status {}: {}",
-            response.status(),
+            status,
             error_text
         ))
     }


### PR DESCRIPTION
## Summary
Fixed clippy/linter warnings and errors in the MCP codebase and investigated the GitHub App authentication failure we observed in the docs job.

## MCP Linter Fixes  
- **Unused variable**: Removed unused task_id parameter in handle_send_job_input function
- **Borrow-of-moved-value**: Fixed by saving response.status() before calling response.text()
- **Result**: All clippy warnings and errors now resolved

## Authentication Investigation Results
Investigated the GitHub App authentication failure in the docs job:

### Root Cause Identified
The docs job authentication failure was NOT due to broken JWT generation code. The current container templates already have correct JWT generation with proper headers.

### Actual Issue  
The docs job was using an old container image that was built before the JWT fixes were applied. Since PR #229 updated the image names (removing /cto/), new jobs will automatically use the updated images with correct authentication.

### Verification
Manual testing confirmed the complete GitHub App authentication flow works perfectly:
- GitHub App: Morgan (5DLabs), App ID 1723711
- Installation: ID 79204627 on 5dlabs org with full permissions  
- JWT generation: Works correctly with proper header.payload.signature format
- Access token generation: Successfully generates valid tokens

## Impact
- MCP code quality: Improved with no warnings/errors
- Authentication: Already working correctly in updated container images
- Future jobs: Will use correct authentication flow automatically

No breaking changes. The MCP input tool continues to work as intended.