### PR TITLE
URGENT: Use GitHub hosted runners to break chicken-and-egg cycle

### DIFF
--- a/.github/workflows/agents-build.yaml
+++ b/.github/workflows/agents-build.yaml
@@ -31,7 +31,7 @@ env:
 
 jobs:
   build-runtime:
-    runs-on: [k8s-runner]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -101,7 +101,7 @@ jobs:
 
   build-agents:
     needs: build-runtime
-    runs-on: [k8s-runner]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/develop-deploy.yaml
+++ b/.github/workflows/develop-deploy.yaml
@@ -50,7 +50,7 @@ jobs:
   # Build only controller (skip Claude Code for now)
   build-controller:
     needs: [version]
-    runs-on: [k8s-runner]
+    runs-on: ubuntu-latest
     # No container needed - the Arc runners now have the rust-builder image!
     permissions:
       contents: read
@@ -226,7 +226,7 @@ jobs:
 
   build-sidecar:
     needs: [version]
-    runs-on: [k8s-runner]
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
@@ -291,7 +291,7 @@ jobs:
   # Deploy immediately
   deploy:
     needs: [version, build-controller]
-    runs-on: [k8s-runner]
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/runner-builld.yaml
+++ b/.github/workflows/runner-builld.yaml
@@ -90,7 +90,7 @@ jobs:
   # Cycle Arc runners to use new image
   cycle-runners:
     needs: build-and-push
-    runs-on: [self-hosted, k8s-runner]  # Run on existing k8s-runner that has kubectl/twingate
+    runs-on: ubuntu-latest  # Temporarily use hosted runner to break chicken-and-egg cycle
     if: github.ref == 'refs/heads/main' || github.ref == 'refs/heads/feature/example-project-and-cli'
     steps:
       - name: Cycle rust-builder runners


### PR DESCRIPTION
## 🚨 URGENT: Break Chicken-and-Egg Cycle with Hosted Runners

## Problem
All self-hosted runners are offline in  trying to pull:
- `ghcr.io/5dlabs/rust-builder:latest` (doesn't exist yet)

## Root Cause  
Classic chicken-and-egg problem:
1. **Self-hosted runners down**: Can't pull new image names (don't exist)
2. **Workflows can't run**: No available runners  
3. **New images can't build**: Workflows are stuck in queue
4. **Cycle continues**: No way forward with current setup

## Solution
**Temporarily use GitHub hosted runners** for critical image-building workflows:
- `runs-on: ubuntu-latest` instead of `runs-on: [k8s-runner]`

## Files Changed
- `.github/workflows/agents-build.yaml` - Build container images (most critical)
- `.github/workflows/develop-deploy.yaml` - Deployment workflows
- `.github/workflows/runner-builld.yaml` - Runner cycling

## Expected Flow  
1. ✅ **Merge immediately** - Workflows can run on hosted runners
2. ✅ **Images get built** - New `ghcr.io/5dlabs/rust-builder:latest` published
3. ✅ **Self-hosted runners recover** - Can pull existing images  
4. ✅ **Follow-up PR** - Switch back to self-hosted runners

## Why This Works
- GitHub hosted runners have no image dependencies
- They can build and push the images our self-hosted runners need
- Breaks the circular dependency

## Next Steps
After merge, monitor:
- Workflow execution on hosted runners
- New image publication to GHCR
- Self-hosted runner recovery