### PR TITLE
fix: resolve Rust builder and controller build issues

### DIFF
--- a/.github/workflows/develop-deploy.yaml
+++ b/.github/workflows/develop-deploy.yaml
@@ -163,7 +163,10 @@ jobs:
           echo "📊 Initial sccache stats:"
           sccache --show-stats
 
-                    # Build with detailed output
+          # Set CARGO_TARGET_DIR to use cache directory
+          export CARGO_TARGET_DIR=$HOME/cache/target
+
+          # Build with detailed output
           echo "⏱️ Starting build..."
           cargo build --release --bin agent-controller
 

--- a/infra/images/builder/Dockerfile
+++ b/infra/images/builder/Dockerfile
@@ -77,12 +77,15 @@ RUN --mount=type=cache,target=/tmp/downloads \
     chmod +x kubectl && \
     mv kubectl /usr/local/bin/
 
-# Install Helm (with caching)
+# Install Helm (with caching) - direct binary download for reliability
 RUN --mount=type=cache,target=/tmp/downloads \
     cd /tmp/downloads && \
-    curl -fsSL -o get_helm.sh https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 && \
-    chmod 700 get_helm.sh && \
-    ./get_helm.sh
+    HELM_VERSION="v3.16.1" && \
+    curl -fsSLO "https://get.helm.sh/helm-${HELM_VERSION}-linux-amd64.tar.gz" && \
+    tar -zxf "helm-${HELM_VERSION}-linux-amd64.tar.gz" && \
+    mv linux-amd64/helm /usr/local/bin/helm && \
+    chmod +x /usr/local/bin/helm && \
+    helm version --client
 
 # Install GitHub CLI (separate layer for better caching)
 RUN --mount=type=cache,target=/var/cache/apt,sharing=locked \


### PR DESCRIPTION
1. Fix Rust Builder Dockerfile:
   - Replace hanging Helm script with direct binary download
   - Use reliable get.helm.sh direct download approach
   - Add version verification step

2. Fix Controller build cache directory issue:
   - Add missing 'export CARGO_TARGET_DIR=/Users/jonathonfritz/cache/target'
   - Align with working sidecar build pattern
   - Ensures binary is built where expected for Docker context

These fixes address the two main build failures:
- Infrastructure workflow hanging at Helm install
- Deploy workflow failing to find controller binary