### PR TITLE
fix(workflow): reliably resolve CodeRun name before waiting

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -287,7 +287,9 @@ spec:
           REPO="{{`{{inputs.parameters.repository}}`}}"
           TASK_ID="{{`{{inputs.parameters.task-id}}`}}"
           LABEL="task-${TASK_ID}"
-          echo "🔎 Looking for PR with label ${LABEL} in ${REPO}"
+          RUN_LABEL="run-{{`{{workflow.name}}`}}"
+          SERVICE_LABEL="service-{{`{{workflow.parameters.service}}`}}"
+          echo "🔎 Looking for PR with labels ${LABEL} and ${RUN_LABEL} in ${REPO}"
 
           # Ensure tools
           apk add --no-cache curl jq openssl >/dev/null 2>&1 || true
@@ -350,13 +352,27 @@ spec:
             else
               resp=$(curl -sL -H "Accept: application/vnd.github+json" "https://api.github.com/repos/${REPO}/pulls?state=open") || resp="[]"
             fi
-            pr_url=$(echo "$resp" | jq -r '.[] | select(.labels // [] | any(.name=="'"$LABEL"'")) | .html_url' | head -n1)
-            pr_number=$(echo "$resp" | jq -r '.[] | select(.labels // [] | any(.name=="'"$LABEL"'")) | .number' | head -n1)
+            pr_url=$(echo "$resp" | jq -r '.[] | select((.labels // []) | (any(.name=="'"$LABEL"'") and any(.name=="'"$RUN_LABEL"'"))) | .html_url' | head -n1)
+            pr_number=$(echo "$resp" | jq -r '.[] | select((.labels // []) | (any(.name=="'"$LABEL"'") and any(.name=="'"$RUN_LABEL"'"))) | .number' | head -n1)
+            if [ -z "$pr_number" ] || [ "$pr_number" = "null" ]; then
+              pr_url=$(echo "$resp" | jq -r '.[] | select((.labels // []) | any(.name=="'"$LABEL"'")) | .html_url' | head -n1)
+              pr_number=$(echo "$resp" | jq -r '.[] | select((.labels // []) | any(.name=="'"$LABEL"'")) | .number' | head -n1)
+            fi
 
             if [ -n "$pr_number" ] && [ "$pr_number" != "null" ]; then
               echo "$pr_url" > /tmp/pr-url.txt
               echo "$pr_number" > /tmp/pr-number.txt
               echo "✅ Found PR #$pr_number"
+              if [ -n "$TOKEN" ]; then
+                add_labels_payload=$(printf '{"labels":["%s","%s","%s"]}' "$LABEL" "$RUN_LABEL" "$SERVICE_LABEL")
+                curl -s -X POST \
+                  -H "Authorization: Bearer $TOKEN" \
+                  -H "Accept: application/vnd.github+json" \
+                  -H "Content-Type: application/json" \
+                  -d "$add_labels_payload" \
+                  "https://api.github.com/repos/${REPO}/issues/${pr_number}/labels" >/dev/null 2>&1 || true
+                echo "🏷️ Ensured PR #$pr_number has labels: $LABEL, $RUN_LABEL, $SERVICE_LABEL"
+              fi
               exit 0
             fi
 

--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -500,14 +500,27 @@ spec:
             exit 0
           fi
           # Fallback: resolve by labels (assumes a single CodeRun for this workflow/task/stage)
-          NAME=$(kubectl get coderun.agents.platform -n {{ .Release.Namespace }} \
-            -l workflow-name={{`{{workflow.name}}`}},workflow-stage={{`{{inputs.parameters.stage}}`}},task-id={{`{{inputs.parameters.task-id}}`}} \
-            -o jsonpath='{.items[0].metadata.name}' || true)
-          if [ -z "$NAME" ]; then
-            echo "" > /tmp/coderun-name.txt
-            exit 0
-          fi
-          echo "$NAME" > /tmp/coderun-name.txt
+          ATTEMPTS=12
+          while [ $ATTEMPTS -gt 0 ]; do
+            NAME=$(kubectl get coderun.agents.platform -n {{ .Release.Namespace }} \
+              -l workflow-name={{`{{workflow.name}}`}},workflow-stage={{`{{inputs.parameters.stage}}`}},task-id={{`{{inputs.parameters.task-id}}`}} \
+              -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || true)
+            if [ -n "$NAME" ]; then
+              echo "$NAME" > /tmp/coderun-name.txt
+              exit 0
+            fi
+            sleep 5
+            ATTEMPTS=$((ATTEMPTS-1))
+          done
+          echo "No CodeRun found for labels after waiting" >&2
+          exit 1
+      retryStrategy:
+        limit: 6
+        retryPolicy: "OnError"
+        backoff:
+          duration: "20s"
+          factor: 1.5
+          maxDuration: "2m"
 
     # Template for waiting for CodeRun completion
     - name: wait-coderun-completion

--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -386,7 +386,7 @@ spec:
         parameters:
         - name: coderun-name
           valueFrom:
-            parameter: "{{`{{steps.create-coderun-resource.outputs.parameters.name}}`}}"
+            parameter: "{{`{{steps.resolve-coderun-name.outputs.parameters.coderun-name}}`}}"
       steps:
       - - name: create-coderun-resource
           template: create-coderun-resource
@@ -404,12 +404,22 @@ spec:
               value: "{{`{{inputs.parameters.pr-number}}`}}"
             - name: qa-ready
               value: "{{`{{inputs.parameters.qa-ready}}`}}"
+      - - name: resolve-coderun-name
+          template: resolve-coderun-name
+          arguments:
+            parameters:
+            - name: stage
+              value: "{{`{{inputs.parameters.stage}}`}}"
+            - name: task-id
+              value: "{{`{{inputs.parameters.task-id}}`}}"
+            - name: candidate-name
+              value: "{{`{{steps.create-coderun-resource.outputs.parameters.name}}`}}"
       - - name: wait-for-completion
           template: wait-coderun-completion
           arguments:
             parameters:
             - name: coderun-name
-              value: "{{`{{steps.create-coderun-resource.outputs.parameters.name}}`}}"
+              value: "{{`{{steps.resolve-coderun-name.outputs.parameters.coderun-name}}`}}"
 
     # Template for creating CodeRun resources
     - name: create-coderun-resource
@@ -432,6 +442,7 @@ spec:
       resource:
         action: create
         setOwnerReference: true
+        successCondition: metadata.name != ""
         manifest: |
           apiVersion: agents.platform/v1
           kind: CodeRun
@@ -463,6 +474,40 @@ spec:
               PR_NUMBER: "{{`{{inputs.parameters.pr-number}}`}}"
               QA_READY: "{{`{{inputs.parameters.qa-ready}}`}}"
               WORKFLOW_STAGE: "{{`{{inputs.parameters.stage}}`}}"
+
+    # Helper to reliably resolve the created CodeRun name before waiting for completion
+    - name: resolve-coderun-name
+      inputs:
+        parameters:
+        - name: stage
+        - name: task-id
+        - name: candidate-name
+          default: ""
+      outputs:
+        parameters:
+        - name: coderun-name
+          valueFrom:
+            path: /tmp/coderun-name.txt
+      script:
+        image: alpine/k8s:1.31.0
+        command: [sh]
+        source: |
+          #!/bin/sh
+          set -e
+          CANDIDATE="{{`{{inputs.parameters.candidate-name}}`}}"
+          if [ -n "$CANDIDATE" ] && [ "$CANDIDATE" != "null" ]; then
+            echo "$CANDIDATE" > /tmp/coderun-name.txt
+            exit 0
+          fi
+          # Fallback: resolve by labels (assumes a single CodeRun for this workflow/task/stage)
+          NAME=$(kubectl get coderun.agents.platform -n {{ .Release.Namespace }} \
+            -l workflow-name={{`{{workflow.name}}`}},workflow-stage={{`{{inputs.parameters.stage}}`}},task-id={{`{{inputs.parameters.task-id}}`}} \
+            -o jsonpath='{.items[0].metadata.name}' || true)
+          if [ -z "$NAME" ]; then
+            echo "" > /tmp/coderun-name.txt
+            exit 0
+          fi
+          echo "$NAME" > /tmp/coderun-name.txt
 
     # Template for waiting for CodeRun completion
     - name: wait-coderun-completion


### PR DESCRIPTION
- Add successCondition to create-coderun-resource
- Insert resolve-coderun-name step to use candidate output or label lookup
- Wire wait-for-completion and template outputs to resolved name