### PR TITLE
Fix/argo-controller-config

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -25,7 +25,6 @@ spec:
   workflowMetadata:
     labels:
       workflow-type: play-orchestration
-      workflows.argoproj.io/controller-instanceid: default
 
   # Main entry point
   entrypoint: main

--- a/infra/gitops/applications/argo-workflows.yaml
+++ b/infra/gitops/applications/argo-workflows.yaml
@@ -30,12 +30,32 @@ spec:
         controller:
           image:
             tag: v3.7.0-rc4
+          # Increase parallelism limits to prevent workflow blocking
+          parallelism: 50
+          namespaceParallelism: 10
+          # Configure controller to watch multiple namespaces
+          # Note: This requires the controller to NOT use instanceID filtering
+          instanceID: ""
+          # Watch both argo and agent-platform namespaces
+          workflowNamespaces:
+            - argo
+            - agent-platform
         server:
           image:
             tag: v3.7.0-rc4
         executor:
           image:
             tag: v3.7.0-rc4
+
+        # Controller configuration via ConfigMap
+        config:
+          parallelism: 50
+          namespaceParallelism: 10
+          namespace: "agent-platform,argo"
+          nodeEvents:
+            enabled: true
+          workflowEvents:
+            enabled: true
 
         # Use values from our local configuration file
         artifactRepository:


### PR DESCRIPTION
- Increase parallelism limit from default (10) to 50 to prevent workflow blocking
- Configure controller to watch both 'argo' and 'agent-platform' namespaces
- Remove instanceID filtering to allow controller to manage all workflows
- Remove controller-instanceid label from play-workflow-template
- Add namespaceParallelism limit of 10 per namespace

These changes fix the issue where workflows in agent-platform namespace were not
being processed by the controller, causing them to get stuck in Pending state.