### PR TITLE
fix: Remove invalid successCondition and add PR correlation labels

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
@@ -1119,30 +1119,55 @@ echo '════════════════════════�
 echo "Claude has completed successfully."
 
 # =============================================================================
-# PR LABELING (task/run/service) — applied by Rex at PR creation/update time
+# PR DETECTION AND LABELING
 # =============================================================================
-if [ -n "${GITHUB_TOKEN:-}" ] && [ -n "${PR_NUMBER:-}" ]; then
-  echo "🏷️ Ensuring correlation labels on PR #${PR_NUMBER}"
+# After Claude completes, check if a PR was created and apply correlation labels
+if [ -n "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
+  echo "🔍 Checking for PRs created by this task..."
+  
+  # First, try to find PR by task label (Claude should have added task-N label)
   TASK_LABEL="task-${TASK_ID}"
-  RUN_LABEL="run-${WORKFLOW_NAME:-unknown}"
-  SERVICE_LABEL="service-${SERVICE_NAME:-unknown}"
-  add_labels_payload=$(printf '{"labels":["%s","%s","%s"]}' "$TASK_LABEL" "$RUN_LABEL" "$SERVICE_LABEL")
-  REPO_SLUG="{{repository_url}}"
-  # Normalize URL to owner/repo slug if needed
-  if echo "$REPO_SLUG" | grep -q '^https://github.com/'; then
-    OWNER=$(echo "$REPO_SLUG" | sed -E 's|https://github.com/([^/]+)/.*|\1|')
-    NAME=$(echo "$REPO_SLUG" | sed -E 's|https://github.com/[^/]+/([^/]+)(\.git)?|\1|')
-    REPO_SLUG="$OWNER/$NAME"
+  PR_NUMBER=$(gh pr list -R "{{repository_url}}" --label "$TASK_LABEL" --json number --jq '.[0].number' 2>/dev/null || true)
+  
+  # If not found by label, try by branch name (current branch)
+  if [ -z "$PR_NUMBER" ]; then
+    CURRENT_BRANCH=$(git rev-parse --abbrev-ref HEAD 2>/dev/null || true)
+    if [ -n "$CURRENT_BRANCH" ] && [ "$CURRENT_BRANCH" != "main" ]; then
+      PR_NUMBER=$(gh pr list -R "{{repository_url}}" --head "$CURRENT_BRANCH" --json number --jq '.[0].number' 2>/dev/null || true)
+    fi
   fi
-  curl -s -X POST \
-    -H "Authorization: Bearer $GITHUB_TOKEN" \
-    -H "Accept: application/vnd.github+json" \
-    -H "Content-Type: application/json" \
-    -d "$add_labels_payload" \
-    "https://api.github.com/repos/${REPO_SLUG}/issues/${PR_NUMBER}/labels" >/dev/null 2>&1 || true
-  echo "🏷️ Labels ensured: $TASK_LABEL, $RUN_LABEL, $SERVICE_LABEL"
+  
+  if [ -n "$PR_NUMBER" ]; then
+    echo "✅ Found PR #${PR_NUMBER}"
+    
+    # Apply correlation labels
+    echo "🏷️ Adding correlation labels to PR #${PR_NUMBER}..."
+    RUN_LABEL="run-${WORKFLOW_NAME:-unknown}"
+    SERVICE_LABEL="service-${SERVICE_NAME:-unknown}"
+    
+    # Use gh CLI to add labels (simpler than curl)
+    if gh pr edit "$PR_NUMBER" -R "{{repository_url}}" --add-label "${RUN_LABEL},${SERVICE_LABEL}" 2>/dev/null; then
+      echo "✅ Added correlation labels: $RUN_LABEL, $SERVICE_LABEL"
+    else
+      echo "⚠️ Failed to add correlation labels (they may not exist)"
+      
+      # Try to create the labels if they don't exist
+      echo "🏷️ Creating missing labels..."
+      gh label create "$RUN_LABEL" -R "{{repository_url}}" --color "0366d6" --description "Workflow run correlation" 2>/dev/null || true
+      gh label create "$SERVICE_LABEL" -R "{{repository_url}}" --color "0e8a16" --description "Service correlation" 2>/dev/null || true
+      
+      # Try again to add the labels
+      if gh pr edit "$PR_NUMBER" -R "{{repository_url}}" --add-label "${RUN_LABEL},${SERVICE_LABEL}" 2>/dev/null; then
+        echo "✅ Labels created and added successfully"
+      else
+        echo "⚠️ Could not add labels even after creating them"
+      fi
+    fi
+  else
+    echo "ℹ️ No PR found for this task (Claude may not have created one)"
+  fi
 else
-  echo "ℹ️ Skipping PR labeling: missing GITHUB_TOKEN or PR_NUMBER"
+  echo "ℹ️ Skipping PR labeling: missing GITHUB_TOKEN or gh CLI"
 fi
 
 # Write sentinel file to signal sidecar to stop (Kubernetes-native file watch)

--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -458,7 +458,6 @@ spec:
       resource:
         action: create
         setOwnerReference: true
-        successCondition: metadata.name != ""
         manifest: |
           apiVersion: agents.platform/v1
           kind: CodeRun


### PR DESCRIPTION
## Summary

This PR fixes two critical issues in the play workflow:

1. **Invalid successCondition causing workflow failure**
   - Removed `metadata.name != ""` condition that was causing parse errors
   - Kubernetes label selectors don't support != with empty strings
   - The resource creation will fail naturally if unsuccessful

2. **Missing PR correlation labels**
   - Rex now automatically detects and labels PRs after Claude completes
   - Uses GitHub CLI to find PR by task label or branch name
   - Applies `run-<workflow>` and `service-<name>` labels
   - Creates labels if they don't exist

## Testing
- Tested `gh pr list` commands to verify they work correctly
- The successCondition removal allows the workflow to proceed
- PR labeling ensures proper correlation for multi-agent orchestration

## Impact
- Fixes workflow blocking issue (Error: exit status 64)
- Ensures PRs are properly labeled for workflow tracking
- Enables Cleo and Tess agents to find the correct PR