### PR TITLE
fix(controller): trigger workflow resumption for already succeeded CodeRuns

### DIFF
--- a/controller/src/tasks/code/controller.rs
+++ b/controller/src/tasks/code/controller.rs
@@ -92,6 +92,10 @@ async fn reconcile_code_create_or_update(code_run: Arc<CodeRun>, ctx: &Context) 
                     true,
                 )
                 .await?;
+
+                // Handle workflow resumption for already succeeded CodeRuns
+                handle_workflow_resumption_on_completion(&code_run, ctx).await?;
+                
                 return Ok(Action::await_change());
             }
             "Failed" => {


### PR DESCRIPTION
## Problem

The workflow resumption logic was only being called in the `CodeJobState::Completed` branch, but CodeRuns that were already 'Succeeded' took the early return path (lines 85-95) and never triggered workflow resumption.

This caused workflows to remain stuck even when CodeRuns had succeeded, because the controller would see the 'Succeeded' status and return early without calling the new workflow resumption logic.

## Solution

Add workflow resumption trigger to the 'Succeeded' branch so that:
- CodeRuns that are already succeeded will trigger workflow resumption
- Handles the case where controller missed the initial completion event
- Ensures workflows progress even if controller restarts after CodeRun completion

## Testing

This fixes the current test case where:
- CodeRun `coderun-implementation-task1-x5s5v` has `phase: Succeeded`
- Workflow `play-task-1-7jbxs` is stuck with `create-coderun-resource: Pending`
- Controller should trigger timeout handler since `pull_request_url: None`

## Impact

Eliminates the workflow stuck issue by ensuring workflow resumption logic runs for all succeeded CodeRuns, regardless of when the controller processes them.