### PR TITLE
fix(rex): Add CodeRun status update with PR URL

### DIFF
--- a/controller/src/tasks/code/resources.rs
+++ b/controller/src/tasks/code/resources.rs
@@ -650,6 +650,19 @@ impl<'a> CodeResourceManager<'a> {
                     }
                 }
             }),
+            // Add CodeRun metadata for status updates
+            json!({
+                "name": "CODERUN_NAME",
+                "value": code_run.name_any()
+            }),
+            json!({
+                "name": "NAMESPACE",
+                "valueFrom": {
+                    "fieldRef": {
+                        "fieldPath": "metadata.namespace"
+                    }
+                }
+            }),
         ];
 
         // Process task requirements if present

--- a/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
@@ -1140,6 +1140,34 @@ if [ -n "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
   if [ -n "$PR_NUMBER" ]; then
     echo "✅ Found PR #${PR_NUMBER}"
     
+    # Get the PR URL
+    PR_URL="https://github.com/{{repository_url}}/pull/${PR_NUMBER}"
+    echo "📝 PR URL: $PR_URL"
+    
+    # Update CodeRun status with PR URL via Kubernetes API
+    echo "🔄 Updating CodeRun status with PR URL..."
+    if command -v kubectl >/dev/null 2>&1; then
+      # Create a patch to update the CodeRun status
+      PATCH_JSON=$(cat <<EOF
+{
+  "status": {
+    "pullRequestUrl": "$PR_URL",
+    "lastUpdate": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  }
+}
+EOF
+)
+      
+      # Apply the patch to update CodeRun status
+      if kubectl patch coderun "$CODERUN_NAME" -n "$NAMESPACE" --type=merge --subresource=status -p "$PATCH_JSON" 2>/dev/null; then
+        echo "✅ Updated CodeRun status with PR URL"
+      else
+        echo "⚠️ Failed to update CodeRun status (kubectl patch failed)"
+      fi
+    else
+      echo "⚠️ kubectl not available, cannot update CodeRun status"
+    fi
+    
     # Apply correlation labels
     echo "🏷️ Adding correlation labels to PR #${PR_NUMBER}..."
     RUN_LABEL="run-${WORKFLOW_NAME:-unknown}"


### PR DESCRIPTION
## Problem
Rex was creating PRs successfully but never updating the CodeRun status with the PR URL. This caused:
- Controller timeout handler to run indefinitely 
- Workflow to remain stuck in 'Running' state
- Cleo never starting because workflow didn't progress

## Root Cause
Rex script found and labeled PRs correctly, but never called the Kubernetes API to update the CodeRun status with the PR URL.

## Solution
1. **Added environment variables** to controller job creation:
   - `CODERUN_NAME`: Name of the current CodeRun resource
   - `NAMESPACE`: Kubernetes namespace (via fieldRef)

2. **Enhanced Rex script** to update CodeRun status:
   - After finding PR, construct PR URL
   - Use `kubectl patch` to update CodeRun status with PR URL
   - This triggers controller workflow resumption logic

## Expected Result
- Rex creates PR ✅
- Rex updates CodeRun status with PR URL ✅  
- Controller detects PR URL in status ✅
- Controller triggers workflow resumption ✅
- Workflow progresses to Cleo stage ✅
- **Cleo finally runspush -u origin fix/rex-pr-status-update* 🎯

## Files Changed
- `controller/src/tasks/code/resources.rs`: Add CODERUN_NAME/NAMESPACE env vars
- `infra/charts/controller/claude-templates/code/container-rex.sh.hbs`: Add kubectl patch for PR URL

This should finally fix the core issue preventing Cleo from running after Rex completes.