### PR TITLE
hotfix: fix ConfigMap annotation size limit (262KB)

### DIFF
--- a/infra/charts/controller/templates/claude-templates-configmap.yaml
+++ b/infra/charts/controller/templates/claude-templates-configmap.yaml
@@ -6,13 +6,12 @@ metadata:
   labels:
     {{- include "controller.labels" . | nindent 4 }}
   annotations:
-    # Force ConfigMap update on redeploy by including template file checksums
-    {{- range $path, $content := .Files.Glob "claude-templates/**/*.hbs" }}
-    checksum/{{ $path | trimPrefix "claude-templates/" | replace "/" "_" }}: {{ $.Files.Get $path | sha256sum }}
+    # Force ConfigMap update on redeploy with aggregated template checksum
+    {{- $allFiles := "" }}
+    {{- range $path, $content := .Files.Glob "claude-templates/**/*" }}
+    {{- $allFiles = print $allFiles $path ($.Files.Get $path) }}
     {{- end }}
-    {{- range $path, $content := .Files.Glob "claude-templates/**/*.sh" }}
-    checksum/{{ $path | trimPrefix "claude-templates/" | replace "/" "_" }}: {{ $.Files.Get $path | sha256sum }}
-    {{- end }}
+    checksum/claude-templates: {{ $allFiles | sha256sum }}
 data:
 {{- range $path, $content := .Files.Glob "claude-templates/**/*.hbs" }}
   {{ $path | trimPrefix "claude-templates/" | replace "/" "_" }}: |


### PR DESCRIPTION
## Summary
- Fix ConfigMap annotation size exceeding Kubernetes 262KB limit
- Replace individual file checksums with single aggregated checksum

## Problem
ArgoCD sync failing with: `ConfigMap "controller-claude-templates" is invalid: metadata.annotations: Too long: may not be more than 262144 bytes`

## Test plan
- [ ] ArgoCD sync completes successfully  
- [ ] Controller deploys without annotation size errors
- [ ] Template ConfigMap updates properly on changes

🤖 Generated with [Claude Code](https://claude.ai/code)