### PR TITLE
fix(templates): correct claude.md.hbs template reference path

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
@@ -317,7 +317,7 @@ Map code changes to required documentation:
 - <10s analysis time for typical PRs
 - Zero tolerance for quality issues
 
-{{> claude.md.hbs}}
+{{> code_claude.md.hbs}}
 EOF
     echo "✓ Created Cleo-specific CLAUDE.md memory"
 fi

--- a/infra/charts/controller/claude-templates/code/container-tess.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-tess.sh.hbs
@@ -359,7 +359,7 @@ After confirming functionality:
 - Do NOT merge PR - only approve
 - Human (CTO) performs final merge
 
-{{> claude.md.hbs}}
+{{> code_claude.md.hbs}}
 EOF
     echo "✓ Created Tess-specific CLAUDE.md memory"
 fi


### PR DESCRIPTION
Both Cleo and Tess containers were referencing {{> claude.md.hbs}} but the
ConfigMap stores this template as 'code_claude.md.hbs' due to path-based naming.

This was causing template resolution failures:
'Error rendering container_script line 321: Partial not found claude.md.hbs'

Now references the correct ConfigMap key to match the working Rex pattern.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>