### PR TITLE
fix(workflows): add CodeRun completion detection to create-coderun-resource

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -458,6 +458,8 @@ spec:
       resource:
         action: create
         setOwnerReference: true
+        successCondition: status.phase == Succeeded
+        failureCondition: status.phase == Failed
         manifest: |
           apiVersion: agents.platform/v1
           kind: CodeRun


### PR DESCRIPTION
## Problem

The Rex→Cleo→Tess pipeline was stalling because the create-coderun-resource workflow step never reported completion.

## Solution

Added successCondition and failureCondition to wait for CodeRun completion:

```yaml
successCondition: status.phase == Succeeded
failureCondition: status.phase == Failed
```

## Impact

Fixes pipeline stall and enables full Rex→Cleo→Tess orchestration.

🤖 Generated with [Claude Code](https://claude.ai/code)