### PR TITLE
feat: add jupiter namespace to platform project destinations

### DIFF
--- a/infra/gitops/projects/platform-project.yaml
+++ b/infra/gitops/projects/platform-project.yaml
@@ -63,6 +63,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: ngrok-operator
       server: https://kubernetes.default.svc
+    - namespace: jupiter
+      server: https://kubernetes.default.svc
     - namespace: kube-system
       server: https://kubernetes.default.svc
     - namespace: default


### PR DESCRIPTION
- Add jupiter namespace to Argo CD platform project destinations
- Allows Jupiter applications to be deployed via Argo CD
- Required for external secrets to work in jupiter namespace