### PR TITLE
Update play-workflow-template.yaml and argo-workflows.yaml for versioning and cleanup

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -25,7 +25,6 @@ spec:
   workflowMetadata:
     labels:
       workflow-type: play-orchestration
-      workflows.argoproj.io/controller-instanceid: default
 
   # Main entry point
   entrypoint: main
@@ -464,7 +463,7 @@ spec:
           apiVersion: agents.platform/v1
           kind: CodeRun
           metadata:
-            generateName: "coderun-{{`{{inputs.parameters.stage}}`}}-task{{`{{inputs.parameters.task-id}}`}}-"
+            generateName: "coderun-{{`{{inputs.parameters.stage}}`}}-task{{`{{inputs.parameters.task-id}}`}}"
             namespace: {{ .Release.Namespace }}
             labels:
               task-id: "{{`{{inputs.parameters.task-id}}`}}"

--- a/infra/gitops/applications/argo-workflows.yaml
+++ b/infra/gitops/applications/argo-workflows.yaml
@@ -26,16 +26,16 @@ spec:
     helm:
       valueFiles: []
       values: |
-        # Override images to use v3.7.0-rc4 pre-release
+        # Use v3.7.1 stable release
         controller:
           image:
-            tag: v3.7.0-rc4
+            tag: v3.7.1
           workflowDefaults:
             spec:
               parallelism: 10
         server:
           image:
-            tag: v3.7.0-rc4
+            tag: v3.7.1
           authModes:
             - server
           service:
@@ -43,7 +43,7 @@ spec:
             nodePort: 30081
         executor:
           image:
-            tag: v3.7.0-rc4
+            tag: v3.7.1
 
         # Use values from our local configuration file
         artifactRepository:


### PR DESCRIPTION
- Removed obsolete label from play-workflow-template.yaml to streamline metadata.
- Updated image tags in argo-workflows.yaml from v3.7.0-rc4 to v3.7.1 for stable release.

These changes enhance clarity and ensure the use of the latest stable images.