### PR TITLE
fix: restore PR parameter passing to quality and testing agents

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -129,7 +129,7 @@ spec:
 
           # Stage 2: Quality work
           - name: quality-work
-            dependencies: [update-to-waiting-pr-created]
+            dependencies: [implementation-cycle, update-to-waiting-pr-created]
             template: agent-coderun
             arguments:
               parameters:
@@ -168,7 +168,7 @@ spec:
 
           # Stage 3: Testing work
           - name: testing-work
-            dependencies: [wait-ready-for-qa]
+            dependencies: [implementation-cycle, wait-ready-for-qa]
             template: agent-coderun
             arguments:
               parameters:


### PR DESCRIPTION
Issue: After adding intermediate stage update steps, quality-work and testing-work
lost access to implementation-cycle outputs because dependency chain was broken.

Root cause:
- quality-work dependency changed from [implementation-cycle] to [update-to-waiting-pr-created]
- testing-work dependency was [wait-ready-for-qa] only
- But both still reference {{tasks.implementation-cycle.outputs.parameters.pr-*}}
- Without direct dependency, those outputs are not available in DAG context

Fix: Add implementation-cycle as explicit dependency for both downstream tasks
- quality-work: dependencies: [implementation-cycle, update-to-waiting-pr-created]
- testing-work: dependencies: [implementation-cycle, wait-ready-for-qa]

This ensures PR_NUMBER and PR_URL environment variables are properly populated
for Cleo and Tess, enabling PR checkout and labeling functionality.

Resolves: Empty PR context preventing agents from proper PR workflow integration

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>