### PR TITLE
fix(cleo): add missing git credential helper configuration

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
@@ -123,6 +123,10 @@ if [ -n "$GITHUB_APP_PRIVATE_KEY" ] && [ -n "$GITHUB_APP_ID" ]; then
     git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
     git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
     
+    # Configure git to use the token (use --replace-all to handle multiple existing helpers)
+    git config --global --replace-all credential.helper store
+    echo "https://x-access-token:${GITHUB_TOKEN}@github.com" > ~/.git-credentials
+    
     # Configure GitHub CLI with the token
     echo "$GITHUB_TOKEN" | gh auth login --with-token
     


### PR DESCRIPTION
Issue: Cleo authentication failing for git operations (fetch, pull) with error:
"remote: Invalid username or token. Password authentication is not supported"

Root cause: Cleo container script missing git credential helper setup that
Rex and Tess have. While GitHub App authentication works for API calls,
git operations need credential.helper store configuration.

Fix: Add missing git credential configuration to match Rex/Tess pattern:
- git config --global --replace-all credential.helper store
- echo "https://x-access-token:${GITHUB_TOKEN}@github.com" > ~/.git-credentials

This enables Cleo to:
- Fetch PR branches for quality review
- Pull latest changes during PR checkout
- Perform git operations needed for code quality workflow

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>