### PR TITLE
fix(rex): add missing task-ID label to PRs for webhook correlation

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
@@ -381,6 +381,11 @@ echo "🎯 Focus: Rigorous code quality enforcement"
 echo "⚠️  CRITICAL: Must pass all quality checks before adding 'ready-for-qa' label"
 echo "════════════════════════════════════════════════════════════════"
 
+# Export necessary variables for Claude execution
+export SERVICE_NAME="{{service}}"
+export TASK_ID="{{task_id}}"
+export GITHUB_APP="{{github_app}}"
+
 # Start Claude with Cleo-specific configuration
 cd "$CLAUDE_WORK_DIR"
 

--- a/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
@@ -1231,22 +1231,24 @@ EOF
     
     # Apply correlation labels
     echo "🏷️ Adding correlation labels to PR #${PR_NUMBER}..."
+    TASK_LABEL="task-${TASK_ID}"
     RUN_LABEL="run-${WORKFLOW_NAME:-unknown}"
     SERVICE_LABEL="service-${SERVICE_NAME:-unknown}"
     
     # Use gh CLI to add labels (simpler than curl)
-    if gh pr edit "$PR_NUMBER" -R "{{docs_repository_url}}" --add-label "${RUN_LABEL},${SERVICE_LABEL}" 2>/dev/null; then
-      echo "✅ Added correlation labels: $RUN_LABEL, $SERVICE_LABEL"
+    if gh pr edit "$PR_NUMBER" -R "{{docs_repository_url}}" --add-label "${TASK_LABEL},${RUN_LABEL},${SERVICE_LABEL}" 2>/dev/null; then
+      echo "✅ Added correlation labels: $TASK_LABEL, $RUN_LABEL, $SERVICE_LABEL"
     else
       echo "⚠️ Failed to add correlation labels (they may not exist)"
       
       # Try to create the labels if they don't exist
       echo "🏷️ Creating missing labels..."
+      gh label create "$TASK_LABEL" -R "{{docs_repository_url}}" --color "f29513" --description "Task correlation" 2>/dev/null || true
       gh label create "$RUN_LABEL" -R "{{docs_repository_url}}" --color "0366d6" --description "Workflow run correlation" 2>/dev/null || true
       gh label create "$SERVICE_LABEL" -R "{{docs_repository_url}}" --color "0e8a16" --description "Service correlation" 2>/dev/null || true
       
       # Try again to add the labels
-      if gh pr edit "$PR_NUMBER" -R "{{docs_repository_url}}" --add-label "${RUN_LABEL},${SERVICE_LABEL}" 2>/dev/null; then
+      if gh pr edit "$PR_NUMBER" -R "{{docs_repository_url}}" --add-label "${TASK_LABEL},${RUN_LABEL},${SERVICE_LABEL}" 2>/dev/null; then
         echo "✅ Labels created and added successfully"
       else
         echo "⚠️ Could not add labels even after creating them"


### PR DESCRIPTION
- Rex was searching for task-ID labels but never adding them to PRs
- Added TASK_LABEL variable to correlation labeling section
- Include task-ID label in both success and fallback label addition attempts
- Ensures webhook sensors can properly correlate PRs to suspended workflows

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>