### PR TITLE
fix(sensors): update GitHub bot login patterns to match actual webhook payloads

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -148,7 +148,7 @@ spec:
           - path: body.sender.login
             type: string
             comparator: "~"
-            value: "5DLabs-Cleo.*"
+            value: "cleo-5dlabs\\[bot\\]"
   triggers:
     - template:
         name: resume-after-ready-for-qa
@@ -264,7 +264,7 @@ spec:
           - path: body.review.user.login
             type: string
             comparator: "~"
-            value: "5DLabs-Tess.*"
+            value: "tess-5dlabs\\[bot\\]"
   triggers:
     - template:
         name: resume-after-pr-approved
@@ -388,7 +388,7 @@ spec:
           - path: body.pusher.name
             type: string
             comparator: "~"
-            value: "5DLabs-(Rex|Blaze|Morgan)(\\[bot\\])?|5DLabs-(Rex|Blaze|Morgan)"
+            value: "(rex|blaze|morgan)-5dlabs\\[bot\\]"
           # Ensure push is to a task branch
           - path: body.ref
             type: string


### PR DESCRIPTION
- Fix Cleo sender pattern: 5DLabs-Cleo.* → cleo-5dlabs[bot]
- Fix Tess reviewer pattern: 5DLabs-Tess.* → tess-5dlabs[bot]
- Fix implementation agent patterns: 5DLabs-Rex.* → rex-5dlabs[bot]

The actual webhook payloads use the format '{agent}-5dlabs[bot]' not '5DLabs-{agent}.*'
This was preventing the ready-for-qa sensor from triggering Tess activation.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>