### PR TITLE
fix(workflow): remove race condition in testing work dependencies

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -168,7 +168,7 @@ spec:
 
           # Stage 3: Testing work
           - name: testing-work
-            dependencies: [implementation-cycle, wait-ready-for-qa]
+            dependencies: [wait-ready-for-qa]
             template: agent-coderun
             arguments:
               parameters:


### PR DESCRIPTION
Testing work should only depend on ready-for-qa label, not quality work completion.
This prevents race conditions where Cleo adds the label before finishing.
The label addition IS the completion signal for quality work.

Before: testing-work dependencies: [implementation-cycle, wait-ready-for-qa]
After:  testing-work dependencies: [wait-ready-for-qa]

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>