### PR TITLE
fix(sensors): convert regex filter values to array format

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -148,7 +148,7 @@ spec:
           - path: body.sender.login
             type: string
             comparator: "~"
-            value: "cleo-5dlabs\\[bot\\]"
+            value: ["cleo-5dlabs\\[bot\\]"]
   triggers:
     - template:
         name: resume-after-ready-for-qa
@@ -264,7 +264,7 @@ spec:
           - path: body.review.user.login
             type: string
             comparator: "~"
-            value: "tess-5dlabs\\[bot\\]"
+            value: ["tess-5dlabs\\[bot\\]"]
   triggers:
     - template:
         name: resume-after-pr-approved
@@ -388,12 +388,12 @@ spec:
           - path: body.pusher.name
             type: string
             comparator: "~"
-            value: "(rex|blaze|morgan)-5dlabs\\[bot\\]"
+            value: ["(rex|blaze|morgan)-5dlabs\\[bot\\]"]
           # Ensure push is to a task branch
           - path: body.ref
             type: string
             comparator: "~"
-            value: "refs/heads/(task|feature/task)-.*"
+            value: ["refs/heads/(task|feature/task)-.*"]
   triggers:
     # Cancel running quality/testing agents
     - template:


### PR DESCRIPTION
Argo Events requires all filter values to be arrays, even for regex comparators.
This fixes the parsing error preventing sensor event processing:

'json: cannot unmarshal string into Go struct field DataFilter.items.spec.dependencies.filters.data.value of type []string'

Changes:
- Cleo sender filter: "cleo-5dlabs\[bot\]" → ["cleo-5dlabs\[bot\]"]
- Tess reviewer filter: "tess-5dlabs\[bot\]" → ["tess-5dlabs\[bot\]"]
- Implementation pusher filter: "(rex|blaze|morgan)-5dlabs\[bot\]" → ["(rex|blaze|morgan)-5dlabs\[bot\]"]
- Branch ref filter: "refs/heads/(task|feature/task)-.*" → ["refs/heads/(task|feature/task)-.*"]

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>