### PR TITLE
Fix/template-substitution-debug

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -176,6 +176,14 @@ spec:
               spec:
                 entrypoint: resume-workflow
                 serviceAccountName: argo-workflow
+                arguments:
+                  parameters:
+                    - name: label-name
+                      value: "{{ .Input.body.label.name }}"
+                    - name: sender-login
+                      value: "{{ .Input.body.sender.login }}"
+                    - name: pr-labels
+                      value: "{{ .Input.body.pull_request.labels | toJson }}"
                 templates:
                   - name: resume-workflow
                     script:
@@ -186,11 +194,11 @@ spec:
                         set -e
 
                         echo "=== Ready-for-QA Workflow Resume ==="
-                        echo "Label Added: {{ .Input.body.label.name }}"
-                        echo "Added By: {{ .Input.body.sender.login }}"
+                        echo "Label Added: {{workflow.parameters.label-name}}"
+                        echo "Added By: {{workflow.parameters.sender-login}}"
 
                         # Extract task ID from PR labels
-                        TASK_ID=$(echo '{{ .Input.body.pull_request.labels }}' | \
+                        TASK_ID=$(echo '{{workflow.parameters.pr-labels}}' | \
                           jq -r '.[] | select(.name | startswith("task-")) | .name | capture("task-(?<id>[0-9]+)") | .id' | head -1)
 
                         if [ -z "$TASK_ID" ]; then
@@ -292,6 +300,16 @@ spec:
               spec:
                 entrypoint: resume-workflow
                 serviceAccountName: argo-workflow
+                arguments:
+                  parameters:
+                    - name: reviewer-login
+                      value: "{{ .Input.body.review.user.login }}"
+                    - name: review-state
+                      value: "{{ .Input.body.review.state }}"
+                    - name: pr-labels
+                      value: "{{ .Input.body.pull_request.labels | toJson }}"
+                    - name: merge-sha
+                      value: "{{ .Input.body.pull_request.merge_commit_sha }}"
                 templates:
                   - name: resume-workflow
                     script:
@@ -302,11 +320,11 @@ spec:
                         set -e
 
                         echo "=== PR Approved Workflow Resume ==="
-                        echo "Reviewer: {{ .Input.body.review.user.login }}"
-                        echo "Review State: {{ .Input.body.review.state }}"
+                        echo "Reviewer: {{workflow.parameters.reviewer-login}}"
+                        echo "Review State: {{workflow.parameters.review-state}}"
 
                         # Extract task ID from PR labels
-                        TASK_ID=$(echo '{{ .Input.body.pull_request.labels }}' | \
+                        TASK_ID=$(echo '{{workflow.parameters.pr-labels}}' | \
                           jq -r '.[] | select(.name | startswith("task-")) | .name | capture("task-(?<id>[0-9]+)") | .id' | head -1)
 
                         if [ -z "$TASK_ID" ]; then
@@ -338,7 +356,7 @@ spec:
                           echo "Found workflow at correct stage, resuming..."
 
                           # Store merge SHA in environment variable to prevent injection
-                          MERGE_SHA="{{ .Input.body.pull_request.merge_commit_sha }}"
+                          MERGE_SHA="{{workflow.parameters.merge-sha}}"
 
                           # Update workflow parameters using strategic patch to preserve existing parameters
                           kubectl patch workflow $WORKFLOW_NAME \

--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -40,6 +40,14 @@ spec:
               spec:
                 entrypoint: resume-workflow
                 serviceAccountName: argo-workflow
+                arguments:
+                  parameters:
+                    - name: pr-number
+                      value: "{{ .Input.body.pull_request.number }}"
+                    - name: pr-url
+                      value: "{{ .Input.body.pull_request.html_url }}"
+                    - name: pr-labels
+                      value: "{{ .Input.body.pull_request.labels | toJson }}"
                 templates:
                   - name: resume-workflow
                     script:
@@ -50,11 +58,11 @@ spec:
                         set -e
 
                         echo "=== PR Created Workflow Resume ==="
-                        echo "PR Number: {{ .Input.body.pull_request.number }}"
-                        echo "PR URL: {{ .Input.body.pull_request.html_url }}"
+                        echo "PR Number: {{workflow.parameters.pr-number}}"
+                        echo "PR URL: {{workflow.parameters.pr-url}}"
 
                         # Extract task ID from PR labels
-                        TASK_ID=$(echo '{{ .Input.body.pull_request.labels }}' | \
+                        TASK_ID=$(echo '{{workflow.parameters.pr-labels}}' | \
                           jq -r '.[] | select(.name | startswith("task-")) | .name | capture("task-(?<id>[0-9]+)") | .id' | head -1)
 
                         if [ -z "$TASK_ID" ]; then
@@ -86,8 +94,8 @@ spec:
                           echo "Found workflow at correct stage, resuming..."
 
                           # Store PR details in environment variables to prevent injection
-                          PR_URL="{{ .Input.body.pull_request.html_url }}"
-                          PR_NUMBER="{{ .Input.body.pull_request.number }}"
+                          PR_URL="{{workflow.parameters.pr-url}}"
+                          PR_NUMBER="{{workflow.parameters.pr-number}}"
 
                           # Update workflow parameters with PR details using strategic patch
                           kubectl patch workflow $WORKFLOW_NAME \


### PR DESCRIPTION
PROBLEM: Template substitution completely broken after array format changes
- Webhook variables like {{ .Input.body.pull_request.number }} appeared literally
- No webhook data passed to workflows, causing automation failures
- Rex→Cleo→Tess pipeline broken

ROOT CAUSE: Mixing sensor-level and workflow-level template processing
- Sensors use Go template syntax with .Input data during creation
- Workflows use parameter syntax during execution
- Previous structure tried to use .Input inside workflow scripts (impossible)

SOLUTION: Proper template structure with parameter passing
1. Sensor extracts webhook data using {{ .Input.body.* }} at creation time
2. Passes extracted data as workflow arguments.parameters
3. Workflow scripts use {{workflow.parameters.*}} syntax

FIXED SENSORS:
✅ play-workflow-pr-created: PR creation webhook processing
✅ play-workflow-ready-for-qa: Cleo→Tess automation (CRITICAL)
✅ play-workflow-pr-approved: Tess→completion automation

This should restore complete webhook automation functionality.

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>