### PR TITLE
Fix: Webhook sensor trigger type from argoWorkflow to k8s

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -25,7 +25,7 @@ spec:
     - template:
         name: resume-after-pr-created
         conditions: "github-pr-created"
-        argoWorkflow:
+        k8s:
           operation: create
           source:
             resource:
@@ -158,7 +158,7 @@ spec:
     - template:
         name: resume-after-ready-for-qa
         conditions: "github-label-added"
-        argoWorkflow:
+        k8s:
           operation: create
           source:
             resource:
@@ -270,7 +270,7 @@ spec:
     - template:
         name: resume-after-pr-approved
         conditions: "github-pr-approved"
-        argoWorkflow:
+        k8s:
           operation: create
           source:
             resource:
@@ -380,7 +380,7 @@ spec:
     - template:
         name: cancel-outdated-agents
         conditions: "github-rex-push"
-        argoWorkflow:
+        k8s:
           operation: create
           source:
             resource:


### PR DESCRIPTION
## Summary
- Fixes critical "unknown operation type create" error preventing webhook automation
- Changes all 4 sensors from `argoWorkflow:` to `k8s:` trigger type  
- Maintains proper parameter passing structure with `arguments.parameters`
- Required for Argo Events to properly create workflow resources

## Root Cause  
Argo Events doesn't recognize `argoWorkflow.operation: create` - the correct syntax is `k8s.operation: create` for Kubernetes resource creation.

## Testing
After this fix, webhook sensors should be able to create resume workflows successfully when PR events are received.

🤖 Generated with [Claude Code](https://claude.ai/code)