### PR TITLE
Fix: Add ready-for-qa label in Cleo container script

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
@@ -503,6 +503,34 @@ fi
 
 # Wait for Claude process to complete
 wait "$CLAUDE_PID"
+CLAUDE_EXIT_CODE=$?
+
+# Add ready-for-qa label if Claude completed successfully
+if [ $CLAUDE_EXIT_CODE -eq 0 ]; then
+  echo "✅ Claude quality review completed successfully"
+  
+  # Add the ready-for-qa label to the PR
+  if [ -n "$PR_NUMBER" ]; then
+    echo "🏷️ Adding 'ready-for-qa' label to PR #$PR_NUMBER..."
+    if gh pr edit "$PR_NUMBER" -R "{{repository_url}}" --add-label "ready-for-qa" 2>/dev/null; then
+      echo "✅ Successfully added 'ready-for-qa' label"
+    else
+      echo "⚠️ Failed to add 'ready-for-qa' label - attempting with full URL..."
+      # Try with the full PR URL as fallback
+      if [ -n "$PR_URL" ]; then
+        if gh pr edit "$PR_URL" --add-label "ready-for-qa" 2>/dev/null; then
+          echo "✅ Successfully added 'ready-for-qa' label using PR URL"
+        else
+          echo "❌ Failed to add 'ready-for-qa' label"
+        fi
+      fi
+    fi
+  else
+    echo "⚠️ No PR_NUMBER available, cannot add label"
+  fi
+else
+  echo "⚠️ Claude process exited with code: $CLAUDE_EXIT_CODE - not adding label"
+fi
 
 # Gracefully stop sidecar
 if curl -fsS -X POST http://127.0.0.1:8080/shutdown >/dev/null 2>&1; then


### PR DESCRIPTION
## Summary
Fixes Cleo not adding the 'ready-for-qa' label after completing code quality reviews.

## Problem
Cleo's container script was missing the code to add the label after Claude completes. Unlike Rex which adds labels programmatically in the script, Cleo was only instructing Claude to add the label in the prompt, but then shutting down immediately after Claude finished.

## Solution
Added label addition logic to Cleo's container script, matching Rex's pattern:
- Check Claude's exit code after completion
- If successful (exit code 0), add the 'ready-for-qa' label using `gh pr edit`
- Try both PR number and PR URL methods for robustness
- Only add label if quality review completed successfully

## Testing
This ensures Cleo will automatically add the label after successful quality reviews, enabling the workflow to proceed to Tess.

🤖 Generated with [Claude Code](https://claude.ai/code)