### PR TITLE
Fix: Add retry logic to handle race condition in ready-for-qa sensor

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -109,8 +109,11 @@ spec:
 
                           # Update workflow parameters with PR info
                           if [ -n "$PR_NUMBER" ] && [ -n "$PR_URL" ]; then
-                            kubectl patch workflow $WORKFLOW_NAME -n agent-platform --type='merge' \
-                              -p "{\"spec\":{\"arguments\":{\"parameters\":[{\"name\":\"pr-url\",\"value\":\"$PR_URL\"},{\"name\":\"pr-number\",\"value\":\"$PR_NUMBER\"}]}}}"
+                            PATCH_JSON="{\"spec\":{\"arguments\":{\"parameters\":["
+                            PATCH_JSON="${PATCH_JSON}{\"name\":\"pr-url\",\"value\":\"$PR_URL\"},"
+                            PATCH_JSON="${PATCH_JSON}{\"name\":\"pr-number\",\"value\":\"$PR_NUMBER\"}]}}}"
+                            kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
+                              --type='merge' -p "$PATCH_JSON"
                           fi
 
                           # Resume the workflow
@@ -183,22 +186,42 @@ spec:
 
                         echo "=== Ready-for-QA Webhook Resume ==="
 
-                        # Find any workflow waiting for QA resumption
-                        WORKFLOW_NAME=$(kubectl get workflows -n agent-platform \
-                          -l current-stage=waiting-ready-for-qa,workflow-type=play-orchestration \
-                          -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+                        # Since we received the webhook, we know Cleo added the label
+                        # The workflow WILL transition to waiting-ready-for-qa, but it might take a few seconds
+                        # Keep trying for up to 2 minutes (24 attempts with 5 second delays)
 
-                        if [ -z "$WORKFLOW_NAME" ]; then
-                          echo "No workflow found waiting for ready-for-qa"
-                          exit 0
-                        fi
+                        MAX_ATTEMPTS=24
+                        ATTEMPT=1
 
-                        echo "Found workflow: $WORKFLOW_NAME"
+                        while [ $ATTEMPT -le $MAX_ATTEMPTS ]; do
+                          echo "Attempt $ATTEMPT/$MAX_ATTEMPTS: Looking for workflow in waiting-ready-for-qa stage..."
 
-                        # Resume the workflow using kubectl patch
-                        kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
-                          --type='merge' -p '{"spec":{"suspend":false}}'
-                        echo "✅ Workflow resumed successfully"
+                          # Find any workflow waiting for QA resumption
+                          WORKFLOW_NAME=$(kubectl get workflows -n agent-platform \
+                            -l current-stage=waiting-ready-for-qa,workflow-type=play-orchestration \
+                            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+                          if [ -n "$WORKFLOW_NAME" ]; then
+                            echo "Found workflow: $WORKFLOW_NAME"
+
+                            # Resume the workflow using kubectl patch
+                            kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
+                              --type='merge' -p '{"spec":{"suspend":false}}'
+                            echo "✅ Workflow resumed successfully"
+                            exit 0
+                          fi
+
+                          if [ $ATTEMPT -lt $MAX_ATTEMPTS ]; then
+                            echo "Workflow not found yet, waiting 5 seconds..."
+                            sleep 5
+                          fi
+
+                          ATTEMPT=$((ATTEMPT + 1))
+                        done
+
+                        echo "❌ ERROR: No workflow found after $MAX_ATTEMPTS attempts"
+                        echo "This suggests the workflow stage transition failed"
+                        exit 1
       retryStrategy:
         steps: 3
         duration: "10s"


### PR DESCRIPTION
## Summary
- Implement retry logic (24 attempts, 5s intervals) in ready-for-qa webhook sensor to handle race condition
- Fix YAML multiline string formatting for kubectl patch command  
- Remove trailing spaces to pass yamllint validation

## Problem
The race condition occurs because:
1. Cleo completes and adds ready-for-qa label (triggers webhook immediately)
2. Workflow updates stage to waiting-ready-for-qa (takes a few seconds)
3. Sensor might not find workflow if stage hasn't updated yet

## Solution
Since the webhook fired, we know the stage transition will happen, so retry until found.

## Changes
- Added retry loop with 24 attempts (2 minutes total) in `play-workflow-sensors.yaml`
- Fixed multiline kubectl patch command formatting
- Cleaned up trailing spaces for yamllint compliance

## Test Plan
- [x] yamllint passes
- [ ] Deploy and test with new workflow run
- [ ] Verify Cleo→Tess transition completes successfully
- [ ] Monitor sensor logs for retry behavior

🤖 Generated with [Claude Code](https://claude.ai/code)