### PR TITLE
Fix: Properly resume suspend nodes in webhook sensors

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -204,10 +204,24 @@ spec:
                           if [ -n "$WORKFLOW_NAME" ]; then
                             echo "Found workflow: $WORKFLOW_NAME"
 
-                            # Resume the workflow using kubectl patch
-                            kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
-                              --type='merge' -p '{"spec":{"suspend":false}}'
-                            echo "✅ Workflow resumed successfully"
+                            # Find the suspended node ID for wait-ready-for-qa
+                            NODE_ID=$(kubectl get workflow $WORKFLOW_NAME -n agent-platform -o json | \
+                              jq -r '.status.nodes | to_entries | .[] | 
+                              select(.value.displayName == "wait-ready-for-qa" and .value.type == "Suspend") | 
+                              .key')
+
+                            if [ -n "$NODE_ID" ]; then
+                              echo "Found suspended node: $NODE_ID"
+                              # Resume the specific suspend node
+                              kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
+                                --type='merge' -p "{\"status\":{\"nodes\":{\"$NODE_ID\":{\"phase\":\"Succeeded\"}}}}"
+                              echo "✅ Suspend node resumed successfully"
+                            else
+                              echo "Warning: Could not find suspend node, trying workflow-level resume"
+                              kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
+                                --type='merge' -p '{"spec":{"suspend":false}}'
+                              echo "✅ Workflow resumed (fallback method)"
+                            fi
                             exit 0
                           fi
 
@@ -296,10 +310,24 @@ spec:
 
                         echo "Found workflow: $WORKFLOW_NAME"
 
-                        # Resume the workflow using kubectl patch
-                        kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
-                          --type='merge' -p '{"spec":{"suspend":false}}'
-                        echo "✅ Workflow resumed successfully"
+                        # Find the suspended node ID for wait-pr-approved
+                        NODE_ID=$(kubectl get workflow $WORKFLOW_NAME -n agent-platform -o json | \
+                          jq -r '.status.nodes | to_entries | .[] | 
+                          select(.value.displayName == "wait-pr-approved" and .value.type == "Suspend") | 
+                          .key')
+
+                        if [ -n "$NODE_ID" ]; then
+                          echo "Found suspended node: $NODE_ID"
+                          # Resume the specific suspend node
+                          kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
+                            --type='merge' -p "{\"status\":{\"nodes\":{\"$NODE_ID\":{\"phase\":\"Succeeded\"}}}}"
+                          echo "✅ Suspend node resumed successfully"
+                        else
+                          echo "Warning: Could not find suspend node, trying workflow-level resume"
+                          kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
+                            --type='merge' -p '{"spec":{"suspend":false}}'
+                          echo "✅ Workflow resumed (fallback method)"
+                        fi
       retryStrategy:
         steps: 3
         duration: "10s"


### PR DESCRIPTION
## Summary
- Fix webhook sensors to properly resume suspend nodes instead of just setting workflow.spec.suspend=false
- Ensures Tess actually starts after Cleo completes

## Problem
The previous fix only patched `workflow.spec.suspend=false`, but Argo Workflows uses individual suspend nodes (created by the `suspend-for-event` template) that need to be resumed by marking them as Succeeded.

## Solution
Updated both ready-for-qa and pr-approved sensors to:
1. Find the specific suspend node by displayName
2. Mark that node's phase as Succeeded to resume the workflow  
3. Fall back to workflow-level resume if node not found

## Testing
- Manually tested with workflow `play-workflow-template-bc9v6`
- Confirmed Tess CodeRun started after resuming the suspend node
- Verified with: `coderun-testing-task1j85f8` is now Running

🤖 Generated with [Claude Code](https://claude.ai/code)