### PR TITLE
Fix: Tess git clone failure when removing working directory

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-tess.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-tess.sh.hbs
@@ -182,6 +182,8 @@ else
     # If directory exists but isn't a git repo, remove it first
     if [ -d "$CLAUDE_WORK_DIR" ] && [ ! -d "$CLAUDE_WORK_DIR/.git" ]; then
         echo "🧹 Removing non-git directory to prepare for clone..."
+        # Change to parent directory before removing current directory
+        cd "$(dirname "$CLAUDE_WORK_DIR")"
         rm -rf "$CLAUDE_WORK_DIR"
     fi
     


### PR DESCRIPTION
## Problem
Tess was failing to clone the repository with:
```
fatal: Unable to read current working directory: No such file or directory
```

## Root Cause
When the script removes the working directory with `rm -rf`, it's still in that directory. Git clone then fails because the current working directory no longer exists.

## Solution
Change to the parent directory before removing the working directory, matching the pattern that Cleo uses.

## Testing
This fix ensures Tess can properly clone the repository when starting fresh.

🤖 Generated with [Claude Code](https://claude.ai/code)