### PR TITLE
feat: Add merge-to-main sensor for automatic task progression

### DIFF
--- a/cto-config.json
+++ b/cto-config.json
@@ -23,7 +23,7 @@
       "service": "cto"
     },
     "play": {
-      "model": "claude-3-5-sonnet-20241022",
+      "model": "claude-sonnet-4-20250514",
       "implementationAgent": "5DLabs-Rex",
       "qualityAgent": "5DLabs-Cleo",
       "testingAgent": "5DLabs-Tess",

--- a/docs/merge-to-main-workflow-design.md
+++ b/docs/merge-to-main-workflow-design.md
@@ -1,0 +1,236 @@
+# Merge to Main Workflow Design
+
+## Overview
+Replace the current "wait for PR approval" pattern with "wait for merge to main" to properly complete tasks and start the next one in queue.
+
+## Current State
+- Workflow suspends after Tess approval waiting for "PR approved" webhook
+- This is incomplete - PR approval doesn't mean task is done
+- Human (CTO) performs the actual merge
+- No mechanism to start next task after merge
+
+## Proposed Changes
+
+### 1. New Sensor: PR Merged to Main
+```yaml
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: play-workflow-pr-merged
+  namespace: argo
+spec:
+  replicas: 2
+  template:
+    serviceAccountName: argo-events-sa
+  dependencies:
+    - name: github-pr-merged
+      eventSourceName: github
+      eventName: org
+      filters:
+        data:
+          # Filter for pull_request closed events with merged=true
+          - path: headers.X-Github-Event
+            type: string
+            value: ["pull_request"]
+          - path: body.action
+            type: string
+            value: ["closed"]
+          - path: body.pull_request.merged
+            type: bool
+            value: [true]
+          - path: body.pull_request.base.ref
+            type: string
+            value: ["main"]
+  triggers:
+    - template:
+        name: task-completion-handler
+        k8s:
+          operation: create
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: task-complete-
+                namespace: agent-platform
+              spec:
+                entrypoint: handle-task-completion
+                templates:
+                  - name: handle-task-completion
+                    script:
+                      image: alpine/k8s:1.31.0
+                      command: [bash]
+                      source: |
+                        #!/bin/bash
+                        set -e
+                        
+                        echo "=== Task Completion Handler ==="
+                        
+                        # Extract task ID from PR title or labels
+                        PR_TITLE="{{ .Input.body.pull_request.title }}"
+                        PR_LABELS="{{ .Input.body.pull_request.labels }}"
+                        
+                        # Parse task ID (e.g., "Task 1: Initialize..." -> "1")
+                        TASK_ID=$(echo "$PR_TITLE" | grep -oE 'Task ([0-9]+)' | sed 's/Task //')
+                        
+                        if [ -z "$TASK_ID" ]; then
+                          echo "No task ID found in PR title"
+                          exit 0
+                        fi
+                        
+                        echo "Task $TASK_ID completed via merge to main"
+                        
+                        # 1. Mark current orchestration workflow as complete
+                        CURRENT_WORKFLOW=$(kubectl get workflows -n agent-platform \
+                          -l task-id=$TASK_ID,workflow-type=play-orchestration \
+                          --field-selector status.phase=Running \
+                          -o jsonpath='{.items[0].metadata.name}')
+                        
+                        if [ -n "$CURRENT_WORKFLOW" ]; then
+                          # Resume the waiting-for-merge suspend node
+                          NODE_ID=$(kubectl get workflow $CURRENT_WORKFLOW -n agent-platform -o json | \
+                            jq -r '.status.nodes | to_entries | .[] |
+                            select(.value.displayName == "wait-merge-to-main" and .value.type == "Suspend") |
+                            .key')
+                          
+                          if [ -n "$NODE_ID" ]; then
+                            kubectl patch workflow $CURRENT_WORKFLOW -n agent-platform \
+                              --type='merge' -p "{\"status\":{\"nodes\":{\"$NODE_ID\":{\"phase\":\"Succeeded\"}}}}"
+                            echo "✅ Task $TASK_ID workflow completed"
+                          fi
+                        fi
+                        
+                        # 2. Start next task in queue
+                        NEXT_TASK_ID=$((TASK_ID + 1))
+                        echo "Checking if task $NEXT_TASK_ID should be started..."
+                        
+                        # Check if next task exists in documentation
+                        # This would need to query the docs repo or a ConfigMap
+                        # For now, we'll assume tasks 1-29 exist
+                        
+                        if [ $NEXT_TASK_ID -le 29 ]; then
+                          echo "Starting Task $NEXT_TASK_ID..."
+                          
+                          # Create new orchestration workflow for next task
+                          cat <<EOF | kubectl create -f -
+                          apiVersion: argoproj.io/v1alpha1
+                          kind: Workflow
+                          metadata:
+                            generateName: play-task-${NEXT_TASK_ID}-
+                            namespace: agent-platform
+                            labels:
+                              task-id: "$NEXT_TASK_ID"
+                              workflow-type: play-orchestration
+                              triggered-by: task-completion
+                          spec:
+                            entrypoint: orchestrate
+                            serviceAccountName: argo-workflow
+                            arguments:
+                              parameters:
+                                - name: task-id
+                                  value: "$NEXT_TASK_ID"
+                                - name: github-owner
+                                  value: "5dlabs"
+                                - name: github-repo
+                                  value: "cto-play-test"
+                            workflowTemplateRef:
+                              name: play-orchestration-template
+                        EOF
+                          
+                          echo "✅ Task $NEXT_TASK_ID workflow started"
+                        else
+                          echo "No more tasks in queue. All tasks completed!"
+                        fi
+```
+
+### 2. Update Orchestration Workflow
+Change the final suspend stage from `wait-pr-approved` to `wait-merge-to-main`:
+
+```yaml
+# In the orchestration workflow template
+- - name: wait-merge-to-main
+    template: wait-suspend
+    arguments:
+      parameters:
+        - name: stage
+          value: "waiting-merge-to-main"
+```
+
+### 3. Task Queue Management
+Options for managing the task queue:
+
+**Option A: Sequential Processing**
+- Simple: Task N+1 starts when Task N merges
+- Each task gets its own PR/branch
+- Easy to track progress
+
+**Option B: ConfigMap-Based Queue**
+```yaml
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: task-queue
+  namespace: agent-platform
+data:
+  current-task: "1"
+  max-task: "29"
+  status: |
+    task-1: completed
+    task-2: in-progress
+    task-3: pending
+    ...
+```
+
+**Option C: CRD-Based Queue**
+Create a TaskQueue CRD to track state more robustly.
+
+## Workflow Sequence
+
+```mermaid
+sequenceDiagram
+    participant PR as Pull Request
+    participant Human as CTO
+    participant WH as Webhook Sensor
+    participant WF as Current Workflow
+    participant Next as Next Task
+    
+    Note over PR: Rex→Cleo→Tess complete
+    Tess->>PR: Approve PR
+    Human->>PR: Review & Merge to main
+    PR->>WH: Merge event (closed + merged)
+    WH->>WF: Resume wait-merge-to-main
+    WF->>WF: Mark task complete
+    WH->>Next: Start next task workflow
+    Next->>Next: Begin Rex implementation
+```
+
+## Benefits
+
+1. **Proper Task Completion**: Task only marked done when code is in main
+2. **Automatic Progression**: Next task starts immediately after merge
+3. **Clear Audit Trail**: Each task has its own PR and workflow
+4. **Human Control**: CTO maintains merge authority
+5. **No Manual Intervention**: Fully automated task progression
+
+## Implementation Steps
+
+1. Add PR merged sensor to play-workflow-sensors.yaml
+2. Update orchestration workflow template with wait-merge-to-main
+3. Create workflow template reference for consistent orchestration
+4. Test with tasks 1-3 in sequence
+5. Add task queue status monitoring
+
+## Edge Cases
+
+1. **Merge without Approval**: Should still trigger completion
+2. **Direct Push to Main**: Won't trigger sensor (good - maintains process)
+3. **Failed Next Task Start**: Log and alert, don't block current task
+4. **Revert Commits**: Would need separate handling
+5. **Multiple PRs per Task**: Use task ID labels to correlate
+
+## Monitoring
+
+- Add metrics for task completion time
+- Track queue depth
+- Alert on stuck workflows
+- Dashboard showing task progression

--- a/infra/gitops/resources/github-webhooks/kustomization.yaml
+++ b/infra/gitops/resources/github-webhooks/kustomization.yaml
@@ -8,4 +8,5 @@ resources:
   - externalsecret.yaml
   - sa-rbac.yaml
   - play-workflow-sensors.yaml
+  - merge-to-main-sensor.yaml
 

--- a/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
@@ -1,0 +1,347 @@
+---
+# Sensor for PR Merged to Main - Complete task and start next
+apiVersion: argoproj.io/v1alpha1
+kind: Sensor
+metadata:
+  name: play-workflow-pr-merged
+  namespace: argo
+spec:
+  replicas: 2
+  template:
+    serviceAccountName: argo-events-sa
+  dependencies:
+    - name: github-pr-merged
+      eventSourceName: github
+      eventName: org
+      filters:
+        data:
+          # Filter for pull_request closed events with merged=true
+          - path: headers.X-Github-Event
+            type: string
+            value: ["pull_request"]
+          - path: body.action
+            type: string
+            value: ["closed"]
+          - path: body.pull_request.merged
+            type: bool
+            value: [true]
+          - path: body.pull_request.base.ref
+            type: string
+            value: ["main"]
+  triggers:
+    - template:
+        name: task-completion-handler
+        conditions: "github-pr-merged"
+        k8s:
+          operation: create
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: task-complete-
+                namespace: agent-platform
+                labels:
+                  type: task-completion
+                  trigger: merge-to-main
+              spec:
+                entrypoint: handle-task-completion
+                serviceAccountName: argo-workflow
+                activeDeadlineSeconds: 600  # 10 minute timeout
+                arguments:
+                  parameters:
+                    - name: pr-title
+                      value: ""
+                    - name: pr-number
+                      value: ""
+                    - name: pr-url
+                      value: ""
+                    - name: merge-sha
+                      value: ""
+                    - name: merged-by
+                      value: ""
+                parameters:
+                  - name: pr-title
+                    valueFrom:
+                      event: "body.pull_request.title"
+                  - name: pr-number
+                    valueFrom:
+                      event: "body.pull_request.number"
+                  - name: pr-url
+                    valueFrom:
+                      event: "body.pull_request.html_url"
+                  - name: merge-sha
+                    valueFrom:
+                      event: "body.pull_request.merge_commit_sha"
+                  - name: merged-by
+                    valueFrom:
+                      event: "body.pull_request.merged_by.login"
+                templates:
+                  - name: handle-task-completion
+                    script:
+                      image: alpine/k8s:1.31.0
+                      command: [bash]
+                      source: |
+                        #!/bin/bash
+                        set -e
+                        
+                        echo "════════════════════════════════════════════════════════════════"
+                        echo "║                 TASK COMPLETION HANDLER                      ║"
+                        echo "════════════════════════════════════════════════════════════════"
+                        echo "📋 PR Title: {{workflow.parameters.pr-title}}"
+                        echo "🔢 PR Number: {{workflow.parameters.pr-number}}"
+                        echo "🔗 PR URL: {{workflow.parameters.pr-url}}"
+                        echo "📦 Merge SHA: {{workflow.parameters.merge-sha}}"
+                        echo "👤 Merged by: {{workflow.parameters.merged-by}}"
+                        echo "════════════════════════════════════════════════════════════════"
+                        
+                        # Extract task ID from PR title (e.g., "Task 1: Initialize..." -> "1")
+                        PR_TITLE="{{workflow.parameters.pr-title}}"
+                        TASK_ID=$(echo "$PR_TITLE" | grep -oE '[Tt]ask[- ]?([0-9]+)' | sed -E 's/[Tt]ask[- ]?//')
+                        
+                        if [ -z "$TASK_ID" ]; then
+                          echo "⚠️ No task ID found in PR title, checking PR body and branch..."
+                          # Could also check branch name or PR body for task ID
+                          exit 0
+                        fi
+                        
+                        echo "✅ Task $TASK_ID completed via merge to main"
+                        
+                        # ============================================================
+                        # STEP 1: Complete current orchestration workflow
+                        # ============================================================
+                        echo ""
+                        echo "🔍 Looking for running orchestration workflow for task $TASK_ID..."
+                        
+                        CURRENT_WORKFLOW=$(kubectl get workflows -n agent-platform \
+                          -l task-id=$TASK_ID,workflow-type=play-orchestration \
+                          --field-selector status.phase=Running \
+                          -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+                        
+                        if [ -n "$CURRENT_WORKFLOW" ]; then
+                          echo "Found workflow: $CURRENT_WORKFLOW"
+                          
+                          # Find and resume the wait-merge-to-main suspend node
+                          NODE_ID=$(kubectl get workflow $CURRENT_WORKFLOW -n agent-platform -o json | \
+                            jq -r '.status.nodes | to_entries | .[] |
+                            select(.value.displayName == "wait-merge-to-main" and .value.type == "Suspend") |
+                            .key')
+                          
+                          if [ -n "$NODE_ID" ]; then
+                            echo "Resuming suspend node: $NODE_ID"
+                            kubectl patch workflow $CURRENT_WORKFLOW -n agent-platform \
+                              --type='merge' -p "{\"status\":{\"nodes\":{\"$NODE_ID\":{\"phase\":\"Succeeded\"}}}}"
+                            echo "✅ Task $TASK_ID workflow completed successfully"
+                          else
+                            echo "⚠️ No wait-merge-to-main suspend node found"
+                            # Try legacy wait-pr-approved node
+                            NODE_ID=$(kubectl get workflow $CURRENT_WORKFLOW -n agent-platform -o json | \
+                              jq -r '.status.nodes | to_entries | .[] |
+                              select(.value.displayName == "wait-pr-approved" and .value.type == "Suspend") |
+                              .key')
+                            if [ -n "$NODE_ID" ]; then
+                              echo "Found legacy wait-pr-approved node, resuming..."
+                              kubectl patch workflow $CURRENT_WORKFLOW -n agent-platform \
+                                --type='merge' -p "{\"status\":{\"nodes\":{\"$NODE_ID\":{\"phase\":\"Succeeded\"}}}}"
+                              echo "✅ Task $TASK_ID workflow completed (legacy)"
+                            fi
+                          fi
+                        else
+                          echo "ℹ️ No running orchestration workflow found for task $TASK_ID"
+                        fi
+                        
+                        # ============================================================
+                        # STEP 2: Start next task in queue
+                        # ============================================================
+                        NEXT_TASK_ID=$((TASK_ID + 1))
+                        
+                        echo ""
+                        echo "🚀 Preparing to start Task $NEXT_TASK_ID..."
+                        
+                        # Check if we've reached the end of tasks
+                        MAX_TASKS=29  # Configure this based on your task set
+                        if [ $NEXT_TASK_ID -gt $MAX_TASKS ]; then
+                          echo "🎉 All tasks completed! No more tasks in queue."
+                          exit 0
+                        fi
+                        
+                        # Check if next task is already running (avoid duplicates)
+                        EXISTING_NEXT=$(kubectl get workflows -n agent-platform \
+                          -l task-id=$NEXT_TASK_ID,workflow-type=play-orchestration \
+                          --field-selector status.phase=Running \
+                          -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+                        
+                        if [ -n "$EXISTING_NEXT" ]; then
+                          echo "⚠️ Task $NEXT_TASK_ID is already running: $EXISTING_NEXT"
+                          exit 0
+                        fi
+                        
+                        echo "Creating orchestration workflow for Task $NEXT_TASK_ID..."
+                        
+                        # Create the next task workflow
+                        cat <<EOF | kubectl create -f -
+                        apiVersion: argoproj.io/v1alpha1
+                        kind: Workflow
+                        metadata:
+                          generateName: play-task-${NEXT_TASK_ID}-
+                          namespace: agent-platform
+                          labels:
+                            task-id: "$NEXT_TASK_ID"
+                            workflow-type: play-orchestration
+                            triggered-by: task-completion
+                            previous-task: "$TASK_ID"
+                        spec:
+                          entrypoint: orchestrate
+                          serviceAccountName: argo-workflow
+                          activeDeadlineSeconds: 172800  # 48 hours
+                          arguments:
+                            parameters:
+                              - name: task-id
+                                value: "$NEXT_TASK_ID"
+                              - name: github-owner
+                                value: "5dlabs"
+                              - name: github-repo
+                                value: "cto-play-test"
+                              - name: docs-repo
+                                value: "cto"
+                          templates:
+                            - name: orchestrate
+                              steps:
+                                # Stage 1: Rex Implementation
+                                - - name: implementation
+                                    template: run-rex
+                                
+                                # Stage 2: Wait for PR creation
+                                - - name: wait-pr-created
+                                    template: suspend-for-stage
+                                    arguments:
+                                      parameters:
+                                        - name: stage
+                                          value: "waiting-pr-created"
+                                
+                                # Stage 3: Cleo Code Quality
+                                - - name: quality
+                                    template: run-cleo
+                                
+                                # Stage 4: Wait for ready-for-qa label
+                                - - name: wait-ready-for-qa
+                                    template: suspend-for-stage
+                                    arguments:
+                                      parameters:
+                                        - name: stage
+                                          value: "waiting-ready-for-qa"
+                                
+                                # Stage 5: Tess QA Testing
+                                - - name: testing
+                                    template: run-tess
+                                
+                                # Stage 6: Wait for merge to main
+                                - - name: wait-merge-to-main
+                                    template: suspend-for-stage
+                                    arguments:
+                                      parameters:
+                                        - name: stage
+                                          value: "waiting-merge-to-main"
+                                
+                                # Stage 7: Task complete
+                                - - name: task-complete
+                                    template: log-completion
+                            
+                            - name: suspend-for-stage
+                              inputs:
+                                parameters:
+                                  - name: stage
+                              suspend: {}
+                              metadata:
+                                labels:
+                                  current-stage: "{{inputs.parameters.stage}}"
+                            
+                            - name: run-rex
+                              resource:
+                                action: create
+                                manifest: |
+                                  apiVersion: agents.platform/v1
+                                  kind: CodeRun
+                                  metadata:
+                                    generateName: coderun-implementation-task{{workflow.parameters.task-id}}-
+                                    namespace: agent-platform
+                                    labels:
+                                      task-id: "{{workflow.parameters.task-id}}"
+                                      workflow-stage: "implementation"
+                                      agent-type: "rex"
+                                  spec:
+                                    service: "task{{workflow.parameters.task-id}}"
+                                    github_app: "5DLabs-Rex"
+                                    github_owner: "{{workflow.parameters.github-owner}}"
+                                    github_repo: "{{workflow.parameters.github-repo}}"
+                                    docs_repository_url: "https://github.com/{{workflow.parameters.github-owner}}/{{workflow.parameters.docs-repo}}"
+                                    task_id: {{workflow.parameters.task-id}}
+                            
+                            - name: run-cleo
+                              resource:
+                                action: create
+                                manifest: |
+                                  apiVersion: agents.platform/v1
+                                  kind: CodeRun
+                                  metadata:
+                                    generateName: coderun-quality-task{{workflow.parameters.task-id}}-
+                                    namespace: agent-platform
+                                    labels:
+                                      task-id: "{{workflow.parameters.task-id}}"
+                                      workflow-stage: "quality"
+                                      agent-type: "cleo"
+                                  spec:
+                                    service: "task{{workflow.parameters.task-id}}"
+                                    github_app: "5DLabs-Cleo"
+                                    github_owner: "{{workflow.parameters.github-owner}}"
+                                    github_repo: "{{workflow.parameters.github-repo}}"
+                                    # Cleo will find the PR created by Rex
+                            
+                            - name: run-tess
+                              resource:
+                                action: create
+                                manifest: |
+                                  apiVersion: agents.platform/v1
+                                  kind: CodeRun
+                                  metadata:
+                                    generateName: coderun-testing-task{{workflow.parameters.task-id}}-
+                                    namespace: agent-platform
+                                    labels:
+                                      task-id: "{{workflow.parameters.task-id}}"
+                                      workflow-stage: "testing"
+                                      agent-type: "tess"
+                                  spec:
+                                    service: "task{{workflow.parameters.task-id}}"
+                                    github_app: "5DLabs-Tess"
+                                    github_owner: "{{workflow.parameters.github-owner}}"
+                                    github_repo: "{{workflow.parameters.github-repo}}"
+                                    # Tess will find the PR with ready-for-qa label
+                            
+                            - name: log-completion
+                              script:
+                                image: alpine:3.18
+                                command: [sh]
+                                source: |
+                                  echo "✅ Task {{workflow.parameters.task-id}} completed successfully!"
+                                  echo "Merged to main and ready for production."
+                        EOF
+                        
+                        if [ $? -eq 0 ]; then
+                          echo "✅ Successfully started Task $NEXT_TASK_ID workflow"
+                          echo ""
+                          echo "════════════════════════════════════════════════════════════════"
+                          echo "║                    TASK PROGRESSION                          ║"
+                          echo "════════════════════════════════════════════════════════════════"
+                          echo "✅ Task $TASK_ID: COMPLETED"
+                          echo "🚀 Task $NEXT_TASK_ID: STARTED"
+                          echo "📊 Progress: $TASK_ID/$MAX_TASKS tasks completed"
+                          echo "════════════════════════════════════════════════════════════════"
+                        else
+                          echo "❌ Failed to start Task $NEXT_TASK_ID workflow"
+                          exit 1
+                        fi
+      retryStrategy:
+        steps: 3
+        duration: "10s"
+        factor: 2
+        jitter: 0.1


### PR DESCRIPTION
## Summary
This PR adds a new sensor that detects when PRs are merged to main, properly completing tasks and automatically starting the next one in the queue.

## Problem
Currently, workflows suspend waiting for PR approval, but that's not the real completion point. The task is only done when the CTO merges to main. We also have no mechanism to automatically start the next task.

## Solution
- New `play-workflow-pr-merged` sensor that detects PR merge events
- Completes the current task's orchestration workflow
- Automatically starts the next task (1-29) in sequence
- Full orchestration workflow template included inline

## Key Features
1. **Proper Task Completion**: Tasks complete when merged to main, not just approved
2. **Automatic Progression**: Next task starts immediately after merge
3. **Human Control**: CTO maintains merge authority
4. **Duplicate Prevention**: Checks if next task already running
5. **Complete Workflow**: Full Rex→Cleo→Tess orchestration template

## Workflow Changes
- Replaces `wait-pr-approved` with `wait-merge-to-main` stage
- More accurate representation of actual completion gate
- Enables continuous pipeline of all 29 tasks

## Testing
Once deployed, merging a task PR to main will:
1. Complete that task's workflow
2. Automatically start the next task
3. Continue until all 29 tasks are done