### PR TITLE
URGENT: Fix sensor bool type error

### DIFF
--- a/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
@@ -23,8 +23,8 @@ spec:
             type: string
             value: ["closed"]
           - path: body.pull_request.merged
-            type: bool
-            value: [true]
+            type: string
+            value: ["true"]
           - path: body.pull_request.base.ref
             type: string
             value: ["main"]


### PR DESCRIPTION
## Critical Bug Fix

This fixes the sensor error:
```
Internal Server Error: json: cannot unmarshal bool into Go struct field DataFilter.items.spec.dependencies.filters.data.value of type string
```

## Problem
The merge-to-main sensor was using `type: bool` with `value: [true]` for the merged field filter.
Argo Events expects ALL filter values to be strings, even for boolean fields.

## Solution
Changed:
- `type: bool` → `type: string`
- `value: [true]` → `value: ["true"]`

## Impact
Without this fix, the sensor cannot process GitHub webhook events for merged PRs, breaking the entire automated task progression workflow.

This is a critical fix that needs to be merged ASAP.