### PR TITLE
CRITICAL FIX: Workflow template and suspend stage issues

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -192,25 +192,14 @@ spec:
             arguments:
               parameters:
               - name: new-stage
-                value: "waiting-pr-approved"
+                value: "waiting-pr-merged"
               - name: verify-update
                 value: "true"
 
-          # Suspend point 3: Wait for PR approval
-          - name: wait-pr-approved
-            dependencies: [update-to-waiting-approval]
-            template: suspend-for-event
-            arguments:
-              parameters:
-              - name: event-type
-                value: "pr-approved"
-              - name: stage-name
-                value: "waiting-pr-approved"
-
-          # Stage 4: Complete task
-          # Suspend point 4: Wait for PR merged before completing
+          # SKIP PR APPROVAL - GO STRAIGHT TO MERGE
+          # Suspend point 3: Wait for PR merged to main
           - name: wait-pr-merged
-            dependencies: [wait-pr-approved]
+            dependencies: [update-to-waiting-approval]
             template: suspend-for-event
             arguments:
               parameters:

--- a/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
@@ -60,27 +60,6 @@ spec:
                       # Will be populated from event
                     - name: merged-by
                       # Will be populated from event
-          parameters:
-            - dest: spec.arguments.parameters.0.value
-              src:
-                dependencyName: github-pr-merged
-                dataKey: body.pull_request.title
-            - dest: spec.arguments.parameters.1.value
-              src:
-                dependencyName: github-pr-merged
-                dataKey: body.pull_request.number
-            - dest: spec.arguments.parameters.2.value
-              src:
-                dependencyName: github-pr-merged
-                dataKey: body.pull_request.html_url
-            - dest: spec.arguments.parameters.3.value
-              src:
-                dependencyName: github-pr-merged
-                dataKey: body.pull_request.merge_commit_sha
-            - dest: spec.arguments.parameters.4.value
-              src:
-                dependencyName: github-pr-merged
-                dataKey: body.pull_request.merged_by.login
                 templates:
                   - name: handle-task-completion
                     script:
@@ -483,6 +462,27 @@ spec:
                           echo "❌ Failed to start Task $NEXT_TASK_ID workflow"
                           exit 1
                         fi
+          parameters:
+            - dest: spec.arguments.parameters.0.value
+              src:
+                dependencyName: github-pr-merged
+                dataKey: body.pull_request.title
+            - dest: spec.arguments.parameters.1.value
+              src:
+                dependencyName: github-pr-merged
+                dataKey: body.pull_request.number
+            - dest: spec.arguments.parameters.2.value
+              src:
+                dependencyName: github-pr-merged
+                dataKey: body.pull_request.html_url
+            - dest: spec.arguments.parameters.3.value
+              src:
+                dependencyName: github-pr-merged
+                dataKey: body.pull_request.merge_commit_sha
+            - dest: spec.arguments.parameters.4.value
+              src:
+                dependencyName: github-pr-merged
+                dataKey: body.pull_request.merged_by.login
       retryStrategy:
         steps: 3
         duration: "10s"


### PR DESCRIPTION
## Critical Issues Fixed

### 1. Template name 'handle-task-completion' undefined
**Error**: `Failed: invalid spec: template name 'handle-task-completion' undefined`

**Cause**: YAML structure was broken - `templates:` section was incorrectly indented under parameters instead of spec

**Fix**: 
- Moved `templates:` to correct indentation under `spec:`
- Re-added `parameters:` section for event data binding

### 2. Workflow waiting for PR approval instead of merge
**Issue**: Workflows were still suspending at `wait-pr-approved` stage despite our changes to use merge-to-main

**Cause**: The play-workflow-template.yaml still had the old approval flow

**Fix**:
- Removed `wait-pr-approved` stage entirely
- Updated workflow to go directly from testing to `wait-pr-merged`
- Changed stage name from `waiting-pr-approved` to `waiting-pr-merged`

## Impact
Without these fixes:
- ❌ Merge sensor creates broken workflows that immediately fail
- ❌ Workflows wait for wrong event (approval vs merge)
- ❌ Entire automation pipeline is broken

With these fixes:
- ✅ Merge sensor creates valid workflows
- ✅ Workflows correctly wait for merge-to-main
- ✅ Consistent with our new completion flow

**This is a critical fix that needs immediate deployment.**