### PR TITLE
Fix/workflow-next-task-progression

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
@@ -119,15 +119,14 @@ if [ -n "$GITHUB_APP_PRIVATE_KEY" ] && [ -n "$GITHUB_APP_ID" ]; then
     # Clean up temporary key file
     rm -f "$TEMP_KEY_FILE"
     
-    # Set global git config with token
-    git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "https://github.com/"
-    git config --global url."https://x-access-token:${GITHUB_TOKEN}@github.com/".insteadOf "git@github.com:"
+    # Export the token for git to use
+    export GITHUB_TOKEN
     
     # Configure git to use the token (use --replace-all to handle multiple existing helpers)
     git config --global --replace-all credential.helper store
     echo "https://x-access-token:${GITHUB_TOKEN}@github.com" > ~/.git-credentials
     
-    # Configure GitHub CLI with the token
+    # Also authenticate gh CLI with the token
     echo "$GITHUB_TOKEN" | gh auth login --with-token
     
 else

--- a/infra/charts/controller/templates/stage-transitions-template.yaml
+++ b/infra/charts/controller/templates/stage-transitions-template.yaml
@@ -146,23 +146,23 @@ spec:
             - name: github-app
               value: "5DLabs-Tess"
 
-        # Update stage after Tess completes
-        - name: update-to-waiting-approval
+        # Update stage after Tess completes (skip approval)
+        - name: update-to-waiting-merge
           dependencies: [tess-testing]
           template: update-workflow-stage
           arguments:
             parameters:
             - name: new-stage
-              value: waiting-pr-approved
+              value: waiting-pr-merged
 
-        # Wait for PR Approval
-        - name: wait-pr-approved
-          dependencies: [update-to-waiting-approval]
+        # Wait for PR Merge
+        - name: wait-pr-merged
+          dependencies: [update-to-waiting-merge]
           template: suspend-for-event
           arguments:
             parameters:
             - name: stage
-              value: waiting-pr-approved
+              value: waiting-pr-merged
 
     # Suspend template that sets workflow stage and waits for events
     - name: suspend-for-event

--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -186,7 +186,7 @@ spec:
                   value: "true"
 
           # Update stage after testing work completes
-          - name: update-to-waiting-approval
+          - name: update-to-waiting-merge
             dependencies: [testing-work]
             template: update-workflow-stage
             arguments:
@@ -199,7 +199,7 @@ spec:
           # SKIP PR APPROVAL - GO STRAIGHT TO MERGE
           # Suspend point 3: Wait for PR merged to main
           - name: wait-pr-merged
-            dependencies: [update-to-waiting-approval]
+            dependencies: [update-to-waiting-merge]
             template: suspend-for-event
             arguments:
               parameters:
@@ -624,9 +624,9 @@ spec:
                 [[ $new_stage == "waiting-ready-for-qa" ]] && return 0
                 ;;
               "waiting-ready-for-qa")
-                [[ $new_stage == "waiting-pr-approved" ]] && return 0
+                [[ $new_stage == "waiting-pr-merged" ]] && return 0
                 ;;
-              "waiting-pr-approved")
+              "waiting-pr-merged")
                 [[ $new_stage == "completed" ]] && return 0
                 ;;
             esac


### PR DESCRIPTION
- Update stage validation: waiting-ready-for-qa → waiting-pr-merged (not waiting-pr-approved)
- Update step names: update-to-waiting-approval → update-to-waiting-merge
- Update step names: wait-pr-approved → wait-pr-merged
- Fix dependencies to use new step names consistently
- This should resolve 'Invalid stage transition' errors when merging PRs

The workflow now properly supports the skip-approval flow:
pending → waiting-pr-created → waiting-ready-for-qa → waiting-pr-merged → completed

🤖 Generated with [Claude Code](https://claude.ai/code)

Co-Authored-By: Claude <noreply@anthropic.com>