### PR TITLE
CRITICAL: Fix bash syntax causing OpenSSL installation failure

### DIFF
--- a/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
@@ -80,16 +80,26 @@ spec:
                         #!/bin/bash
                         set -e
 
-                        # Install required tools if not present
+                                                # Install required tools if not present
                         MISSING_TOOLS=""
-                        [ ! command -v git &> /dev/null ] && MISSING_TOOLS="$MISSING_TOOLS git"
-                        [ ! command -v curl &> /dev/null ] && MISSING_TOOLS="$MISSING_TOOLS curl"
-                        [ ! command -v jq &> /dev/null ] && MISSING_TOOLS="$MISSING_TOOLS jq"
-                        [ ! command -v openssl &> /dev/null ] && MISSING_TOOLS="$MISSING_TOOLS openssl"
+                        if ! command -v git >/dev/null 2>&1; then
+                          MISSING_TOOLS="$MISSING_TOOLS git"
+                        fi
+                        if ! command -v curl >/dev/null 2>&1; then
+                          MISSING_TOOLS="$MISSING_TOOLS curl"
+                        fi
+                        if ! command -v jq >/dev/null 2>&1; then
+                          MISSING_TOOLS="$MISSING_TOOLS jq"
+                        fi
+                        if ! command -v openssl >/dev/null 2>&1; then
+                          MISSING_TOOLS="$MISSING_TOOLS openssl"
+                        fi
 
                         if [ -n "$MISSING_TOOLS" ]; then
                           echo "Installing missing tools:$MISSING_TOOLS"
                           apk add --no-cache $MISSING_TOOLS
+                        else
+                          echo "All required tools are already available"
                         fi
 
                         # =============================================================================

--- a/infra/runner-cache/cache-pvc.yaml
+++ b/infra/runner-cache/cache-pvc.yaml
@@ -22,3 +22,4 @@ spec:
   storageClassName: local-path  # Adjust based on your storage class
 
 
+

--- a/infra/runner-cache/values.yaml
+++ b/infra/runner-cache/values.yaml
@@ -50,3 +50,4 @@ template:
           claimName: runner-cache-pvc
 
 
+


### PR DESCRIPTION
CRITICAL BUG FIX: This fixes the root cause of the 'openssl: command not found' error in task-complete workflows.

PROBLEM: The previous fix had a bash syntax error. The syntax '[ ! command -v openssl &> /dev/null ]' doesn't work properly inside test brackets.

SOLUTION: Replaced with proper 'if ! command -v openssl >/dev/null 2>&1' syntax.

This should finally resolve the OpenSSL installation issue by ensuring proper command detection and tool installation.