### PR TITLE
fix: Add external-dns Helm repository to platform project sourceRepos

### DIFF
--- a/infra/gitops/projects/platform-project.yaml
+++ b/infra/gitops/projects/platform-project.yaml
@@ -35,6 +35,7 @@ spec:
     - 'https://github.com/actions/actions-runner-controller'
     - 'https://charts.ngrok.com'
     - 'https://github.com/kubernetes-sigs/gateway-api'
+    - 'https://kubernetes-sigs.github.io/external-dns/'
     # Database operator Helm chart repositories
     - 'https://opensource.zalando.com/postgres-operator/charts/postgres-operator'
     - 'https://github.com/spotahome/redis-operator'


### PR DESCRIPTION
- Add https://kubernetes-sigs.github.io/external-dns/ to allowed repositories
- This fixes the 'repo is not permitted in project' error for external-dns application