### PR TITLE
fix: Change external-dns policy to prevent pod crashes

### DIFF
--- a/infra/gitops/applications/external-dns.yaml
+++ b/infra/gitops/applications/external-dns.yaml
@@ -45,7 +45,7 @@ spec:
           - ingress
 
         # Policy for record ownership
-        policy: sync  # sync = manage all records, upsert-only = only create/update
+        policy: upsert-only  # upsert-only = only create/update, don't delete
 
         # Registry for tracking managed records
         registry: txt
@@ -89,6 +89,11 @@ spec:
 
         # Interval for DNS updates
         interval: 1m
+
+        # Additional resilience settings
+        logLevel: info
+        dryRun: false
+        once: false
 
         # Annotations to watch for
         annotationFilter: external-dns.alpha.kubernetes.io/hostname


### PR DESCRIPTION
- Change policy from 'sync' to 'upsert-only' to avoid conflicts with existing DNS records
- Set 'once: false' to run continuously instead of exiting on first error
- This prevents the 'Failed to do run once' fatal errors that crash the pod
- External-dns will now handle existing records gracefully and continue running

Fixes external-dns pod crash loop when encountering pre-existing DNS records.