### PR TITLE
fix: remove invalid TLS mode from NGrok Gateway

### DIFF
--- a/infra/gitops/resources/ngrok-gateway/gateway.yaml
+++ b/infra/gitops/resources/ngrok-gateway/gateway.yaml
@@ -14,8 +14,7 @@ spec:
       protocol: HTTPS
       port: 443
       hostname: "public.5dlabs.ai"
-      tls:
-        mode: Terminate
+      tls: {}
       allowedRoutes:
         namespaces:
           from: All
@@ -23,8 +22,7 @@ spec:
       protocol: HTTPS
       port: 443
       hostname: "github.public.5dlabs.ai"
-      tls:
-        mode: Terminate
+      tls: {}
       allowedRoutes:
         namespaces:
           from: All


### PR DESCRIPTION
Fixes Gateway validation errors by removing invalid TLS mode configuration.

**Problem:**
ArgoCD sync failing with error:
```
Gateway.gateway.networking.k8s.io "public-gateway" is invalid: 
spec.listeners[0].tls: Invalid value: "object": no such key: certificateRefs 
evaluating rule: certificateRefs or options must be specified when mode is Terminate
```

**Root Cause:**
Gateway API requires `certificateRefs` when `mode: Terminate` is specified, but NGrok handles TLS termination automatically.

**Solution:**
- Remove `mode: Terminate` from both Gateway listeners
- Let NGrok handle TLS configuration automatically
- NGrok provides Let's Encrypt certificates for custom domains

**Testing:**
After merge, the ngrok-gateway ArgoCD application should sync successfully without TLS validation errors.