### PR TITLE
fix: remove TLS configuration from NGrok Gateway completely

### DIFF
--- a/infra/gitops/resources/ngrok-gateway/gateway.yaml
+++ b/infra/gitops/resources/ngrok-gateway/gateway.yaml
@@ -14,7 +14,6 @@ spec:
       protocol: HTTPS
       port: 443
       hostname: "public.5dlabs.ai"
-      tls: {}
       allowedRoutes:
         namespaces:
           from: All
@@ -22,7 +21,6 @@ spec:
       protocol: HTTPS
       port: 443
       hostname: "github.public.5dlabs.ai"
-      tls: {}
       allowedRoutes:
         namespaces:
           from: All


### PR DESCRIPTION
**Deep Root Cause Analysis:**

The Gateway API webhook validator was rejecting even empty TLS objects (`tls: {}`) when used with HTTPS protocol.

**What I discovered:**
1. Current Gateway resource has NO TLS section and works perfectly
2. ArgoCD was trying to ADD `tls: {}` from our YAML
3. Gateway API requires `certificateRefs` or `options` if ANY TLS config is present
4. Even empty TLS objects (`tls: {}`) trigger validation errors

**The Fix:**
- Remove TLS configuration entirely from both listeners
- Let NGrok handle TLS automatically (which it already does)
- Match the working configuration of the existing Gateway

**Why this works:**
- NGrok automatically provides Let's Encrypt certificates for HTTPS
- The existing Gateway proves this approach works
- No TLS config = no validation errors

**Testing:**
The existing Gateway works without TLS config, so this should sync successfully.