### PR TITLE
fix: correct NGrok TrafficPolicy rate limit configuration

### DIFF
--- a/infra/gitops/resources/ngrok-gateway/traffic-policy.yaml
+++ b/infra/gitops/resources/ngrok-gateway/traffic-policy.yaml
@@ -18,8 +18,10 @@ spec:
             config:
               name: "webhook-rate-limit"
               algorithm: "sliding_window"
-              capacity: 100
-              rate: "10r/s"
+              capacity: 600
+              rate: "60s"
+              bucket_key:
+                - "conn.client_ip"
     on_http_response:
       - actions:
           - type: add-headers


### PR DESCRIPTION
**Root Cause:**
The NGrok endpoint was offline due to invalid rate limit configuration in the TrafficPolicy.

**Error Details:**
```
ERR_NGROK_2203: Failed to parse rate-limit configuration
invalid duration: unknown unit, expected one of [h m s ms us ns]
rate: "10r/s"
```

**Issues Fixed:**
1. **Invalid rate format**: `"10r/s"` → `"60s"` (NGrok expects duration, not rate/time)
2. **Missing required field**: Added `bucket_key: ["conn.client_ip"]` (required by schema)
3. **Rate calculation**: `capacity: 600` per `60s` = 10 requests/second effective rate

**Configuration Reference:**
Based on NGrok documentation examples:
- Rate must be duration format: `"60s"`, `"10m"`, `"1h"`
- Minimum rate is `"60s"`
- `bucket_key` is required for rate limiting by client IP
- `capacity` / `rate` = effective requests per second

**Testing:**
After merge, the AgentEndpoint should come back online and appear in NGrok UI.