### PR TITLE
Feature/mailu-email-server

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -2,10 +2,10 @@
 apiVersion: argoproj.io/v1alpha1
 kind: Application
 metadata:
-  name: mailu-namespace
+  name: mailu
   namespace: argocd
   labels:
-    app.kubernetes.io/name: mailu-namespace
+    app.kubernetes.io/name: mailu
     app.kubernetes.io/part-of: platform
 spec:
   project: platform
@@ -23,3 +23,9 @@ spec:
     syncOptions:
       - CreateNamespace=true
       - ServerSideApply=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m

--- a/infra/gitops/resources/mailu/postgres-cluster.yaml
+++ b/infra/gitops/resources/mailu/postgres-cluster.yaml
@@ -50,12 +50,12 @@ spec:
 
   # Database users and permissions
   users:
-    # Mailu application user
+    # Mailu application user - needs more permissions for schema creation
     mailu:
       - NOSUPERUSER
       - INHERIT
       - CREATEDB
-      - NOCREATEROLE
+      - CREATEROLE
       - NOREPLICATION
     # Admin user for maintenance
     admin:
@@ -70,6 +70,9 @@ spec:
   preparedDatabases:
     mailu:
       defaultUsers: true
+      schemas:
+        public: {}
+        mailu: {}
       extensions:
         pg_stat_statements: "public"
         uuid-ossp: "public"


### PR DESCRIPTION
- Grant CREATEROLE permission to mailu user for schema operations
- Add explicit schema definitions (public, mailu) in preparedDatabases
- This resolves the 'permission denied for database mailu' error
  when the operator tries to sync prepared database schemas

The mailu user now has sufficient permissions to create and manage
database schemas required by the Zalando PostgreSQL operator.