### PR TITLE
fix(mailu): grant SUPERUSER permissions to resolve schema creation

### DIFF
--- a/infra/gitops/resources/mailu/postgres-cluster.yaml
+++ b/infra/gitops/resources/mailu/postgres-cluster.yaml
@@ -50,13 +50,11 @@ spec:
 
   # Database users and permissions
   users:
-    # Mailu application user - needs more permissions for schema creation
+    # Mailu application user - needs superuser for schema operations with Zalando operator
     mailu:
-      - NOSUPERUSER
-      - INHERIT
+      - SUPERUSER
       - CREATEDB
       - CREATEROLE
-      - NOREPLICATION
     # Admin user for maintenance
     admin:
       - SUPERUSER


### PR DESCRIPTION
- Change mailu user from NOSUPERUSER to SUPERUSER
- This resolves the persistent 'permission denied for database mailu'
  error when Zalando operator tries to sync prepared database schemas
- Delete existing cluster to force recreation with new permissions

The Zalando PostgreSQL operator requires SUPERUSER privileges for
the database owner to properly manage prepared databases and schemas.