### PR TITLE
Feature/mailu-email-server

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -32,12 +32,14 @@ spec:
           password: "ChangeMe123!"
 
         # Database configuration (using our PostgreSQL cluster)
-        database:
+        postgresql:
+          enabled: false
+        externalDatabase:
           type: postgresql
           host: mailu-postgres.databases.svc.cluster.local
           port: 5432
-          name: mailu
-          user: mailu
+          database: mailu
+          username: mailu
           existingSecret: mailu.mailu-postgres.credentials.postgresql.acid.zalan.do
           existingSecretPasswordKey: password
 
@@ -141,9 +143,7 @@ spec:
         persistence:
           enabled: true
           storageClass: local-path
-          size:
-            data: 10Gi
-            mail: 20Gi
+          size: 20Gi
 
         # Ingress for webmail
         ingress:

--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -35,6 +35,7 @@ spec:
         postgresql:
           enabled: false
         externalDatabase:
+          enabled: true
           type: postgresql
           host: mailu-postgres.databases.svc.cluster.local
           port: 5432
@@ -47,10 +48,11 @@ spec:
         subnet: 10.42.0.0/16
 
         # Mail settings
-        messageSizeLimitMb: 50
-        authRatelimit:
-          ip: "60/hour"
-          user: "100/hour"
+        limits:
+          messageSizeLimitInMegabytes: 50
+          authRatelimit:
+            ip: "60/hour"
+            user: "100/day"
 
         # TLS configuration
         tls:
@@ -141,9 +143,9 @@ spec:
 
         # Storage configuration
         persistence:
-          enabled: true
-          storageClass: local-path
+          single_pvc: true
           size: 20Gi
+          storageClass: local-path
 
         # Ingress for webmail
         ingress:


### PR DESCRIPTION
- Add 'enabled: true' to externalDatabase section
- Fix persistence configuration to use single_pvc format
- Update limits section to use correct field names:
  - messageSizeLimitMb -> limits.messageSizeLimitInMegabytes
  - authRatelimit -> limits.authRatelimit
- Change user rate limit from 100/hour to 100/day (matching defaults)

This should resolve all deprecated configuration key errors
from the Mailu Helm chart version 2.2.2.