### PR TITLE
fix(mailu): add additional DNSSEC disable environment variables

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -54,6 +54,8 @@ spec:
               value: "8.8.8.8"
             - name: DISABLE_DNSSEC_VALIDATION
               value: "true"
+            - name: SKIP_DNSSEC_VALIDATION
+              value: "true"
 
         # Mail settings
         limits:


### PR DESCRIPTION
- Add DISABLE_DNSSEC_VALIDATION and SKIP_DNSSEC_VALIDATION env vars
- Try multiple approaches to disable DNSSEC validation in admin container
- This should resolve the persistent DNSSEC validation errors