### PR TITLE
feat(mailu): configure NGrok LoadBalancer for mail ports

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -83,11 +83,25 @@ spec:
             limits:
               memory: "200Mi"
               cpu: "200m"
-          service:
+          # Enable external service for mail ports via NGrok LoadBalancer
+          externalService:
+            enabled: true
             type: LoadBalancer
+            loadBalancerClass: ngrok
+            externalTrafficPolicy: Local
             annotations:
               external-dns.alpha.kubernetes.io/hostname: "mail.5dlabs.ai"
               external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+            ports:
+              # Enable all mail ports
+              pop3: false      # 110/tcp - disable plain POP3
+              pop3s: true      # 995/tcp - secure POP3
+              imap: false      # 143/tcp - disable plain IMAP  
+              imaps: true      # 993/tcp - secure IMAP
+              smtp: true       # 25/tcp - SMTP
+              smtps: true      # 465/tcp - secure SMTP
+              submission: true # 587/tcp - submission
+              manageSieve: true # 4190/tcp - ManageSieve
 
         admin:
           enabled: true
@@ -157,13 +171,12 @@ spec:
           size: 20Gi
           storageClass: local-path
 
-        # Ingress for webmail
+        # Ingress for webmail (using NGrok)
         ingress:
           enabled: true
-          className: nginx
+          ingressClassName: ngrok
           annotations:
             cert-manager.io/cluster-issuer: letsencrypt-prod
-            nginx.ingress.kubernetes.io/proxy-body-size: "50m"
             external-dns.alpha.kubernetes.io/hostname: "webmail.5dlabs.ai"
             external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
           hosts:


### PR DESCRIPTION
- Enable front.externalService with NGrok LoadBalancer for mail ports
- Configure all secure mail ports: IMAPS (993), POP3S (995), SMTP (25),
  SMTPS (465), Submission (587), ManageSieve (4190)
- Disable insecure ports: IMAP (143), POP3 (110)
- Switch ingress to use NGrok ingressClassName for webmail access
- Remove NGINX-specific annotations (proxy-body-size)

This enables proper mail server exposure through NGrok TCP addresses
while maintaining secure connections for all mail protocols.