### PR TITLE
fix(mailu): resolve external-dns conflicts

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -18,11 +18,9 @@ spec:
     helm:
       values: |
         # Mailu Configuration for 5dlabs.ai
-        domain: mail.5dlabs.ai
+        domain: 5dlabs.ai
         hostnames:
           - mail.5dlabs.ai
-          - smtp.5dlabs.ai
-          - imap.5dlabs.ai
 
         # Initial admin configuration
         initialAccount:


### PR DESCRIPTION
- Change domain from 'mail.5dlabs.ai' to '5dlabs.ai' (proper mail domain)
- Reduce hostnames to only 'mail.5dlabs.ai' to avoid DNS conflicts
- This prevents external-dns from trying to create conflicting CNAME records
  for smtp.5dlabs.ai and imap.5dlabs.ai

The LoadBalancer service handles mail.5dlabs.ai for mail ports,
while ingress handles webmail.5dlabs.ai for web interface.