### PR TITLE
fix(mailu): add loadBalancerClass: ngrok for automatic TCP address creation

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -81,9 +81,25 @@ spec:
             limits:
               memory: "200Mi"
               cpu: "200m"
-          # Disable external LoadBalancer service - using AgentEndpoints instead
+          # Enable external LoadBalancer service with NGrok
           externalService:
-            enabled: false
+            enabled: true
+            type: LoadBalancer
+            loadBalancerClass: ngrok
+            externalTrafficPolicy: Local
+            annotations:
+              external-dns.alpha.kubernetes.io/hostname: "mail.5dlabs.ai"
+              external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+            ports:
+              # Enable secure mail ports only
+              pop3: false      # 110/tcp - disable plain POP3
+              pop3s: true      # 995/tcp - secure POP3
+              imap: false      # 143/tcp - disable plain IMAP  
+              imaps: true      # 993/tcp - secure IMAP
+              smtp: true       # 25/tcp - SMTP
+              smtps: true      # 465/tcp - secure SMTP
+              submission: true # 587/tcp - submission
+              manageSieve: true # 4190/tcp - ManageSieve
 
         admin:
           enabled: true


### PR DESCRIPTION
- Re-enable LoadBalancer service with proper loadBalancerClass: ngrok
- This allows NGrok operator to automatically create TCP addresses
- Confirmed working with test service - TCP addresses appear in NGrok UI
- Enables proper mail server port exposure:
  - SMTP (25), SMTPS (465), Submission (587)
  - IMAPS (993), POP3S (995), ManageSieve (4190)

The NGrok operator automatically creates TCP addresses (like 1.tcp.ngrok.io:12345)
for LoadBalancer services with loadBalancerClass: ngrok.