### PR TITLE
fix(mailu): create separate NGrok LoadBalancer for TCP addresses

### DIFF
--- a/infra/gitops/applications/mailu-tcp-endpoints.yaml
+++ b/infra/gitops/applications/mailu-tcp-endpoints.yaml
@@ -16,7 +16,7 @@ spec:
     targetRevision: HEAD
     path: infra/gitops/resources
     directory:
-      include: "mailu-tcp-endpoints.yaml"
+      include: "mailu-tcp-*.yaml"
   destination:
     server: https://kubernetes.default.svc
     namespace: mailu

--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -81,25 +81,10 @@ spec:
             limits:
               memory: "200Mi"
               cpu: "200m"
-          # Enable external LoadBalancer service with NGrok
+          # Disable Helm chart's LoadBalancer - using separate NGrok LoadBalancer instead
+          # (Helm chart doesn't support loadBalancerClass field needed for NGrok)
           externalService:
-            enabled: true
-            type: LoadBalancer
-            loadBalancerClass: ngrok
-            externalTrafficPolicy: Local
-            annotations:
-              external-dns.alpha.kubernetes.io/hostname: "mail.5dlabs.ai"
-              external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
-            ports:
-              # Enable secure mail ports only
-              pop3: false      # 110/tcp - disable plain POP3
-              pop3s: true      # 995/tcp - secure POP3
-              imap: false      # 143/tcp - disable plain IMAP  
-              imaps: true      # 993/tcp - secure IMAP
-              smtp: true       # 25/tcp - SMTP
-              smtps: true      # 465/tcp - secure SMTP
-              submission: true # 587/tcp - submission
-              manageSieve: true # 4190/tcp - ManageSieve
+            enabled: false
 
         admin:
           enabled: true

--- a/infra/gitops/resources/mailu-tcp-loadbalancer.yaml
+++ b/infra/gitops/resources/mailu-tcp-loadbalancer.yaml
@@ -1,0 +1,50 @@
+---
+# NGrok LoadBalancer service for Mailu mail ports
+# This creates TCP addresses automatically via NGrok operator
+apiVersion: v1
+kind: Service
+metadata:
+  name: mailu-tcp-loadbalancer
+  namespace: mailu
+  labels:
+    app.kubernetes.io/name: mailu
+    app.kubernetes.io/component: mail-tcp
+    app.kubernetes.io/part-of: mailu
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "mail.5dlabs.ai"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+spec:
+  type: LoadBalancer
+  loadBalancerClass: ngrok
+  allocateLoadBalancerNodePorts: false
+  externalTrafficPolicy: Local
+  selector:
+    app.kubernetes.io/component: front
+    app.kubernetes.io/instance: mailu
+    app.kubernetes.io/name: mailu
+  ports:
+    # Secure mail ports only
+    - name: smtp
+      port: 25
+      protocol: TCP
+      targetPort: 25
+    - name: smtps
+      port: 465
+      protocol: TCP
+      targetPort: 465
+    - name: submission
+      port: 587
+      protocol: TCP
+      targetPort: 587
+    - name: imaps
+      port: 993
+      protocol: TCP
+      targetPort: 993
+    - name: pop3s
+      port: 995
+      protocol: TCP
+      targetPort: 995
+    - name: sieve
+      port: 4190
+      protocol: TCP
+      targetPort: 4190


### PR DESCRIPTION
- Mailu Helm chart doesn't support loadBalancerClass field
- Create dedicated LoadBalancer service with loadBalancerClass: ngrok
- Disable Helm chart's externalService (lacks NGrok support)
- Update ArgoCD app to include both TCP resources (endpoints + loadbalancer)
- This should automatically create TCP addresses in NGrok for mail ports

The loadBalancerClass field is immutable and must be set at creation time.
Helm chart template doesn't include this field, so we need a separate service.