### PR TITLE
fix(mailu): add Roundcube database configuration to global.database

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -22,6 +22,15 @@ spec:
         hostnames:
           - mail.5dlabs.ai
 
+        # Global database configuration for Roundcube
+        global:
+          database:
+            roundcube:
+              database: roundcube
+              username: roundcube
+              existingSecret: roundcube.mailu-postgres.credentials.postgresql.acid.zalan.do
+              existingSecretPasswordKey: password
+
         # Initial admin configuration
         initialAccount:
           enabled: true


### PR DESCRIPTION
- Add global.database.roundcube configuration pointing to PostgreSQL
- Use roundcube.mailu-postgres.credentials secret for authentication
- This should resolve the admin pod crashes caused by missing database config
- Mailu Helm chart requires both externalDatabase (main) and global.database.roundcube

The admin pods were failing because the chart was defaulting to SQLite
instead of using the external PostgreSQL for both databases.