### PR TITLE
fix(mailu): disable front hostPort to resolve PodSecurity violations

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -55,17 +55,17 @@ spec:
         subnet: 10.42.0.0/16
 
         # DNS configuration to fix DNSSEC validation issue in Kubernetes
-admin:
-  extraEnvVars:
-    - name: RESOLVER_ADDRESS
-      value: "8.8.8.8"
-    - name: DISABLE_DNSSEC_VALIDATION
-      value: "true"
-    - name: SKIP_DNSSEC_VALIDATION
-      value: "true"
-    # Override hardcoded SQLite URI with PostgreSQL connection string
-    - name: SQLALCHEMY_DATABASE_URI
-      value: "postgresql://mailu:$(DB_PW)@mailu-postgres.databases.svc.cluster.local:5432/mailu"
+        admin:
+          extraEnvVars:
+            - name: RESOLVER_ADDRESS
+              value: "8.8.8.8"
+            - name: DISABLE_DNSSEC_VALIDATION
+              value: "true"
+            - name: SKIP_DNSSEC_VALIDATION
+              value: "true"
+            # Override hardcoded SQLite URI with PostgreSQL connection string
+            - name: SQLALCHEMY_DATABASE_URI
+              value: "postgresql://mailu:$(DB_PW)@mailu-postgres.databases.svc.cluster.local:5432/mailu"
 
         # Mail settings
         limits:

--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -93,6 +93,9 @@ spec:
             limits:
               memory: "200Mi"
               cpu: "200m"
+          # Disable hostPort bindings to avoid PodSecurity baseline violations
+          hostPort:
+            enabled: false
           # Disable Helm chart's LoadBalancer - using separate NGrok LoadBalancer instead
           # (Helm chart doesn't support loadBalancerClass field needed for NGrok)
           externalService:


### PR DESCRIPTION
- Add front.hostPort.enabled: false to prevent hostPort bindings
- Resolves PodSecurity baseline violations for ports 25, 110, 143, 465, 587, 993, 995
- Mail ports are exposed via separate NGrok LoadBalancer service instead
- Allows front pods to start successfully without security policy conflicts