### PR TITLE
feat(mailu): increase admin pod resources to 2Gi memory and 2 CPU

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -95,13 +95,13 @@ spec:
           replicaCount: 1
           # Enable debug logging for admin service
           logLevel: DEBUG
-          resources:
-            requests:
-              memory: "512Mi"
-              cpu: "200m"
-            limits:
-              memory: "1Gi"
-              cpu: "1000m"
+                 resources:
+         requests:
+           memory: "1Gi"
+           cpu: "500m"
+         limits:
+           memory: "2Gi"
+           cpu: "2000m"
           # DNS configuration to fix DNSSEC validation issue in Kubernetes
           extraEnvVars:
             - name: RESOLVER_ADDRESS


### PR DESCRIPTION
- Increase admin.resources.requests to 1Gi memory and 500m CPU
- Increase admin.resources.limits to 2Gi memory and 2000m CPU
- This should resolve exit code 137 (OOM killer) during database migration