### PR TITLE
feat(mailu): disable admin probes temporarily for database migration

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -102,6 +102,11 @@ spec:
             limits:
               memory: "2Gi"
               cpu: "2000m"
+          # Disable probes temporarily to allow database migration to complete
+          livenessProbe:
+            enabled: false
+          readinessProbe:
+            enabled: false
           # DNS configuration to fix DNSSEC validation issue in Kubernetes
           extraEnvVars:
             - name: RESOLVER_ADDRESS


### PR DESCRIPTION
- Disable livenessProbe and readinessProbe for admin pod
- This prevents pod restarts during database migration process
- Allows migration to complete without being killed by probe failures
- Can be re-enabled once database is properly initialized