### PR TITLE
fix(mailu): add SSL requirement to PostgreSQL connection string

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -115,9 +115,9 @@ spec:
               value: "true"
             - name: SKIP_DNSSEC_VALIDATION
               value: "true"
-            # Override hardcoded SQLite URI with PostgreSQL connection string
-            - name: SQLALCHEMY_DATABASE_URI
-              value: "postgresql://mailu:$(DB_PW)@mailu-postgres.databases.svc.cluster.local:5432/mailu"
+                       # Override hardcoded SQLite URI with PostgreSQL connection string (with SSL)
+           - name: SQLALCHEMY_DATABASE_URI
+             value: "postgresql://mailu:$(DB_PW)@mailu-postgres.databases.svc.cluster.local:5432/mailu?sslmode=require"
             # Enable Flask debug mode for detailed error messages
             - name: DEBUG
               value: "true"


### PR DESCRIPTION
- Add sslmode=require to SQLALCHEMY_DATABASE_URI
- Resolves pg_hba.conf rejection due to unencrypted connection
- Required for PostgreSQL connections from pods to database cluster