### PR TITLE
feat(mailu): Re-enable health probes after successful database migration

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -89,10 +89,17 @@ spec:
           externalService:
             enabled: false
 
+        # Use latest image tags for all components
+        image:
+          tag: "latest"
+
         # Admin configuration with DNS fixes and database override
         admin:
           enabled: true
           replicaCount: 1
+          # Use latest image tag
+          image:
+            tag: "latest"
           # Enable debug logging for admin service
           logLevel: DEBUG
           resources:
@@ -107,7 +114,7 @@ spec:
             enabled: false
           readinessProbe:
             enabled: false
-          # DNS configuration to fix DNSSEC validation issue in Kubernetes
+          # DNS configuration to use Google DNS directly
           extraEnvVars:
             - name: RESOLVER_ADDRESS
               value: "8.8.8.8"
@@ -115,9 +122,9 @@ spec:
               value: "true"
             - name: SKIP_DNSSEC_VALIDATION
               value: "true"
-                       # Override hardcoded SQLite URI with PostgreSQL connection string (with SSL)
-           - name: SQLALCHEMY_DATABASE_URI
-             value: "postgresql://mailu:$(DB_PW)@mailu-postgres.databases.svc.cluster.local:5432/mailu?sslmode=require"
+            # Override hardcoded SQLite URI with PostgreSQL connection string (with SSL)
+            - name: SQLALCHEMY_DATABASE_URI
+              value: "postgresql://mailu:$(DB_PW)@mailu-postgres.databases.svc.cluster.local:5432/mailu?sslmode=require"
             # Enable Flask debug mode for detailed error messages
             - name: DEBUG
               value: "true"

--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -109,11 +109,11 @@ spec:
             limits:
               memory: "2Gi"
               cpu: "2000m"
-          # Disable probes temporarily to allow database migration to complete
+          # Re-enable probes now that database migration is complete
           livenessProbe:
-            enabled: false
+            enabled: true
           readinessProbe:
-            enabled: false
+            enabled: true
           # DNS configuration to use Google DNS directly
           extraEnvVars:
             - name: RESOLVER_ADDRESS


### PR DESCRIPTION
- Enable liveness and readiness probes for admin pod
- Database migration is complete, probes will now help detect any remaining issues
- This will provide proper health monitoring for the Mailu admin service