### PR TITLE
fix(mailu): Disable TLS in Mailu since NGrok handles external TLS termination

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -64,9 +64,9 @@ spec:
             ip: "60/hour"
             user: "100/day"
 
-        # TLS configuration - using NGrok for external TLS termination
+        # TLS configuration - disabled since NGrok handles external TLS termination
         tls:
-          enabled: true
+          enabled: false
           certmanager:
             enabled: false
 


### PR DESCRIPTION
- Set tls.enabled: false to prevent frontend pods from trying to mount mailu-certificates secret
- NGrok handles TLS termination externally, so Mailu doesn't need internal TLS certificates
- This should resolve the frontend pods stuck in ContainerCreating state