### PR TITLE
refactor: Update CoreDNS configuration to disable DNSSEC validation

### DIFF
--- a/infra/gitops/resources/coredns/coredns-configmap.yaml
+++ b/infra/gitops/resources/coredns/coredns-configmap.yaml
@@ -34,12 +34,10 @@ data:
            health_check 5s
         }
         
-        # Enable DNSSEC-aware caching with proper validation
+        # Basic caching without DNSSEC validation (DNSSEC validation disabled due to CoreDNS compatibility issues)
         cache 30 {
            disable success cluster.local
            disable denial cluster.local
-           # Enable DNSSEC validation in cache
-           dnssec
         }
         
         loop


### PR DESCRIPTION
- Modify CoreDNS ConfigMap to disable DNSSEC validation due to compatibility issues
- Update README to reflect changes in DNS resolution strategy and configuration
- Enhance documentation for clarity on the new caching behavior and upstream resolver reliability

These changes aim to improve stability and compatibility for Talos-managed CoreDNS deployments.