### PR TITLE
fix: revert Mailu to use published Helm chart repo instead of GitHub

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -12,9 +12,9 @@ metadata:
 spec:
   project: platform
   source:
-    repoURL: https://github.com/Mailu/helm-charts.git
-    path: charts/mailu
-    targetRevision: HEAD
+    repoURL: https://mailu.github.io/helm-charts/
+    chart: mailu
+    targetRevision: master
     helm:
       values: |
         # Mailu Configuration for 5dlabs.ai


### PR DESCRIPTION
The GitHub repo doesn't have built dependencies, causing ArgoCD repo server to crash.
Using the published chart repository which has all dependencies included.