### PR TITLE
fix: use correct Mailu chart version 2.2.2 instead of 'master'

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -14,7 +14,7 @@ spec:
   source:
     repoURL: https://mailu.github.io/helm-charts/
     chart: mailu
-    targetRevision: master
+    targetRevision: 2.2.2
     helm:
       values: |
         # Mailu Configuration for 5dlabs.ai


### PR DESCRIPTION
Helm chart repositories use semantic versions, not branch names.