### PR TITLE
Fix/argocd-repo-server-crash

### DIFF
--- a/infra/gitops/applications/mailu-external-secrets.yaml
+++ b/infra/gitops/applications/mailu-external-secrets.yaml
@@ -1,0 +1,24 @@
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mailu-external-secrets
+  namespace: argocd
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/5dlabs/cto.git
+    targetRevision: HEAD
+    path: infra/secret-store
+    directory:
+      include: "mailu-external-secrets.yaml"
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mailu
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true

--- a/infra/secret-store/mailu-external-secrets.yaml
+++ b/infra/secret-store/mailu-external-secrets.yaml
@@ -1,0 +1,31 @@
+---
+# Mailu External Secrets
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: mailu-database-secret
+  namespace: mailu
+spec:
+  refreshInterval: 30s
+  secretStoreRef:
+    name: secret-store
+    kind: ClusterSecretStore
+  target:
+    name: mailu-secret
+    creationPolicy: Owner
+    template:
+      type: Opaque
+      data:
+        # Keep the existing secret-key from Helm
+        secret-key: "{{ .secretkey }}"
+        # Add the database password from PostgreSQL secret
+        DB_PW: "{{ .dbpassword }}"
+  data:
+  - secretKey: secretkey
+    remoteRef:
+      key: mailu-config
+      property: secret_key
+  - secretKey: dbpassword
+    remoteRef:
+      key: mailu-config  
+      property: db_password

--- a/infra/secret-store/namespace-and-rbac.yaml
+++ b/infra/secret-store/namespace-and-rbac.yaml
@@ -72,3 +72,32 @@ subjects:
 - kind: ServiceAccount
   name: external-secrets
   namespace: external-secrets-system
+
+---
+# ClusterRole for External Secrets to manage secrets across namespaces
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: external-secrets-secret-manager
+rules:
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources: ["namespaces"]
+  verbs: ["get", "list", "watch"]
+
+---
+# Bind the cluster role to External Secrets service account for secret management
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRoleBinding
+metadata:
+  name: external-secrets-secret-manager
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: external-secrets-secret-manager
+subjects:
+- kind: ServiceAccount
+  name: external-secrets
+  namespace: external-secrets-system


### PR DESCRIPTION
- Add external-secrets-secret-manager ClusterRole with create/update/patch/delete permissions
- Add ClusterRoleBinding to allow external-secrets to manage secrets in any namespace
- Required for Mailu external secrets to create/update mailu-secret