### PR TITLE
fix(mailu): Use external-secrets managed mailu-secret for DB_PW

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -125,8 +125,8 @@ spec:
             - name: DB_PW
               valueFrom:
                 secretKeyRef:
-                  name: mailu.mailu-postgres.credentials.postgresql.acid.zalan.do
-                  key: password
+                  name: mailu-secret
+                  key: DB_PW
             # Override hardcoded SQLite URI with PostgreSQL connection string (with SSL)
             - name: SQLALCHEMY_DATABASE_URI
               value: "postgresql://mailu:$(DB_PW)@mailu-postgres.databases.svc.cluster.local:5432/mailu?sslmode=require"


### PR DESCRIPTION
- Change admin DB_PW environment variable to reference mailu-secret instead of direct PostgreSQL secret
- This ensures the admin pod uses the password managed by external-secrets
- Fixes database authentication issues after external-secrets implementation