### PR TITLE
fix(mailu): Update externalDatabase to use external-secrets managed secret

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -48,8 +48,8 @@ spec:
           port: 5432
           database: mailu
           username: mailu
-          existingSecret: mailu.mailu-postgres.credentials.postgresql.acid.zalan.do
-          existingSecretPasswordKey: password
+          existingSecret: mailu-secret
+          existingSecretPasswordKey: DB_PW
 
         # Subnet configuration for Kubernetes
         subnet: 10.42.0.0/16


### PR DESCRIPTION
- Change externalDatabase.existingSecret from PostgreSQL secret to mailu-secret
- Change existingSecretPasswordKey from 'password' to 'DB_PW'
- This eliminates duplicate DB_PW environment variables and ensures consistent use of external-secrets