### PR TITLE
Fix/argocd-repo-server-crash

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -109,11 +109,11 @@ spec:
             limits:
               memory: "2Gi"
               cpu: "2000m"
-          # Temporarily disable probes while troubleshooting migration issues
+          # Re-enable probes now that database connection is working
           livenessProbe:
-            enabled: false
+            enabled: true
           readinessProbe:
-            enabled: false
+            enabled: true
           # DNS configuration to use Google DNS directly
           extraEnvVars:
             - name: RESOLVER_ADDRESS

--- a/infra/gitops/resources/mailu-tcp-loadbalancer.yaml
+++ b/infra/gitops/resources/mailu-tcp-loadbalancer.yaml
@@ -11,8 +11,9 @@ metadata:
     app.kubernetes.io/component: mail-tcp
     app.kubernetes.io/part-of: mailu
   annotations:
-    external-dns.alpha.kubernetes.io/hostname: "mail.5dlabs.ai"
-    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+    # Removed custom domain due to NGrok ACL restrictions
+    # external-dns.alpha.kubernetes.io/hostname: "mail.5dlabs.ai"
+    # external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
 spec:
   type: LoadBalancer
   loadBalancerClass: ngrok


### PR DESCRIPTION
- Comment out external-dns hostname annotation for mail.5dlabs.ai
- NGrok credential cr_31KMij5zjM3DKKNoTRBKUSK5MXd lacks ACL permission for custom domains
- This should allow NGrok to create TCP endpoints with auto-generated domains