### PR TITLE
fix(mailu): Update ingress configuration for NGrok compatibility

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -201,10 +201,15 @@ spec:
             external-dns.alpha.kubernetes.io/hostname: "webmail.5dlabs.ai"
             external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
           hosts:
-            - host: webmail.5dlabs.ai
+            - host: mail.5dlabs.ai
               paths:
                 - path: /
                   pathType: Prefix
+                  backend:
+                    service:
+                      name: mailu-front
+                      port:
+                        number: 80  # Use HTTP port 80, NGrok handles HTTPS termination
 
         # Security settings
         securityContext:


### PR DESCRIPTION
- Change ingress host from webmail.5dlabs.ai to mail.5dlabs.ai to match NGrok endpoint
- Explicitly set backend service port to 80 (HTTP) for NGrok HTTPS termination
- Fixes NGrok gateway error ERR_NGROK_3004 by ensuring correct upstream connection

Resolves issues where NGrok was trying to connect via HTTP to HTTPS port 443,
causing invalid/incomplete HTTP response errors.