### PR TITLE
fix(mailu): Create separate ingress with correct backend port configuration

### DIFF
--- a/infra/gitops/applications/mailu-ingress.yaml
+++ b/infra/gitops/applications/mailu-ingress.yaml
@@ -1,0 +1,39 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: mailu-ingress
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: mailu-ingress
+    app.kubernetes.io/part-of: platform
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  source:
+    repoURL: https://github.com/5dlabs/cto.git
+    targetRevision: HEAD
+    path: infra/gitops/resources
+    directory:
+      include: mailu-ingress.yaml
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: mailu
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - SkipDryRunOnMissingResource=true
+      - RespectIgnoreDifferences=true
+    retry:
+      limit: 5
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 3m
+  revisionHistoryLimit: 5

--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -192,24 +192,9 @@ spec:
           size: 20Gi
           storageClass: local-path
 
-        # Ingress for webmail (using NGrok) - NGrok handles TLS termination
+        # Disable Helm chart ingress - we'll create our own with correct port configuration
         ingress:
-          enabled: true
-          ingressClassName: ngrok
-          tls: false  # NGrok handles TLS termination
-          annotations:
-            external-dns.alpha.kubernetes.io/hostname: "webmail.5dlabs.ai"
-            external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
-          hosts:
-            - host: mail.5dlabs.ai
-              paths:
-                - path: /
-                  pathType: Prefix
-                  backend:
-                    service:
-                      name: mailu-front
-                      port:
-                        number: 80  # Use HTTP port 80, NGrok handles HTTPS termination
+          enabled: false
 
         # Security settings
         securityContext:

--- a/infra/gitops/resources/mailu-ingress.yaml
+++ b/infra/gitops/resources/mailu-ingress.yaml
@@ -1,0 +1,28 @@
+---
+# Custom NGrok Ingress for Mailu with correct backend port configuration
+# This replaces the Helm chart ingress which doesn't properly support custom backend ports
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: mailu-ingress
+  namespace: mailu
+  labels:
+    app.kubernetes.io/name: mailu
+    app.kubernetes.io/component: ingress
+    app.kubernetes.io/part-of: mailu
+  annotations:
+    external-dns.alpha.kubernetes.io/hostname: "webmail.5dlabs.ai"
+    external-dns.alpha.kubernetes.io/cloudflare-proxied: "false"
+spec:
+  ingressClassName: ngrok
+  rules:
+    - host: mail.5dlabs.ai
+      http:
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                name: mailu-front
+                port:
+                  number: 80  # Use HTTP port 80, NGrok handles HTTPS termination


### PR DESCRIPTION
- Disable Helm chart ingress (doesn't support custom backend port properly)
- Create custom mailu-ingress.yaml with explicit port 80 backend configuration
- Add mailu-ingress ArgoCD application to manage the custom ingress
- This ensures NGrok connects to HTTP port 80 instead of HTTPS port 443

Resolves recurring ERR_NGROK_3004 gateway errors caused by ArgoCD syncing
the Helm chart and overriding manual ingress patches.