### PR TITLE
fix(mailu): Disable Helm secret creation to avoid conflict with external-secrets

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -51,6 +51,10 @@ spec:
           existingSecret: mailu-secret
           existingSecretPasswordKey: DB_PW
 
+        # Don't create mailu-secret - it's managed by external-secrets
+        secret:
+          create: false
+
         # Subnet configuration for Kubernetes
         subnet: 10.42.0.0/16
 


### PR DESCRIPTION
- Add secret.create: false to prevent Helm from managing mailu-secret
- The mailu-secret is already managed by external-secrets operator
- This resolves the OutOfSync status caused by ownership conflicts

ArgoCD was showing OutOfSync because both Helm and external-secrets
were trying to manage the same secret resource.