### PR TITLE
fix(mailu): Set TLS flavor to 'notls' to prevent redirect loop

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -68,8 +68,9 @@ spec:
             ip: "60/hour"
             user: "100/day"
 
-        # TLS configuration - disabled since NGrok handles external TLS termination
+        # TLS configuration - use 'notls' flavor since NGrok handles external TLS termination
         tls:
+          flavor: notls
           enabled: false
           certmanager:
             enabled: false


### PR DESCRIPTION
- Change tls.flavor from default 'cert' to 'notls'
- Mailu was redirecting HTTP to HTTPS causing infinite redirect loop
- NGrok handles TLS termination, so Mailu should serve plain HTTP

Resolves ERR_TOO_MANY_REDIRECTS error when accessing mail.5dlabs.ai