### PR TITLE
fix(mailu): Add secret.create: false to prevent Helm/external-secrets conflict

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -201,6 +201,10 @@ spec:
           enabled: false
           tlsFlavorOverride: "notls"  # Override TLS_FLAVOR to prevent redirect loop
 
+        # Disable Helm secret creation - managed by external-secrets instead
+        secret:
+          create: false
+
         # Security settings
         securityContext:
           runAsNonRoot: false


### PR DESCRIPTION
This should resolve the ArgoCD OutOfSync status caused by both Helm and
external-secrets trying to manage the mailu-secret.