### PR TITLE
feat(dns): Add Cloudflare redirect configuration for 5dlabs.ai domains

### DIFF
--- a/infra/gitops/applications/cloudflare-redirects.yaml
+++ b/infra/gitops/applications/cloudflare-redirects.yaml
@@ -1,0 +1,51 @@
+---
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: cloudflare-redirects
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: cloudflare-redirects
+    app.kubernetes.io/part-of: platform
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  project: platform
+  
+  source:
+    repoURL: https://github.com/5dlabs/cto
+    targetRevision: HEAD
+    path: infra/gitops/resources/cloudflare-redirects
+
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: external-dns
+
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - SkipDryRunOnMissingResource=true
+      - RespectIgnoreDifferences=true
+    retry:
+      limit: 3
+      backoff:
+        duration: 5s
+        factor: 2
+        maxDuration: 2m
+
+  # Ignore job status changes
+  ignoreDifferences:
+    - group: batch
+      kind: Job
+      jsonPointers:
+        - /status
+        - /metadata/generation
+        - /spec/activeDeadlineSeconds
+
+  revisionHistoryLimit: 5

--- a/infra/gitops/resources/cloudflare-redirects/configmap.yaml
+++ b/infra/gitops/resources/cloudflare-redirects/configmap.yaml
@@ -1,0 +1,87 @@
+---
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: cloudflare-redirect-script
+  namespace: external-dns
+  labels:
+    app.kubernetes.io/name: cloudflare-redirects
+    app.kubernetes.io/part-of: platform
+data:
+  configure-redirects.sh: |
+    #!/bin/bash
+    set -euo pipefail
+    
+    # Configuration
+    ZONE_NAME="5dlabs.ai"
+    REDIRECT_URL="https://github.com/5dlabs"
+    RULE_NAME="5dlabs-to-github"
+    
+    echo "Starting Cloudflare redirect rule configuration..."
+    
+    # Get Zone ID
+    echo "Getting zone ID for $ZONE_NAME..."
+    ZONE_ID=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones?name=$ZONE_NAME" \
+      -H "Authorization: Bearer $CF_API_TOKEN" \
+      -H "Content-Type: application/json" | \
+      jq -r '.result[0].id')
+    
+    if [ "$ZONE_ID" = "null" ] || [ -z "$ZONE_ID" ]; then
+      echo "Error: Could not find zone ID for $ZONE_NAME"
+      exit 1
+    fi
+    
+    echo "Found zone ID: $ZONE_ID"
+    
+    # Check if redirect rule already exists
+    echo "Checking for existing redirect rules..."
+    EXISTING_RULE=$(curl -s -X GET "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/rulesets/phases/http_request_redirect/entrypoint" \
+      -H "Authorization: Bearer $CF_API_TOKEN" \
+      -H "Content-Type: application/json" | \
+      jq -r ".result.rules[]? | select(.description == \"$RULE_NAME\") | .id")
+    
+    # Create the redirect rule configuration
+    RULE_CONFIG=$(cat <<EOF
+    {
+      "rules": [
+        {
+          "description": "$RULE_NAME",
+          "enabled": true,
+          "expression": "(http.host eq \"5dlabs.ai\" or http.host eq \"www.5dlabs.ai\")",
+          "action": "redirect",
+          "action_parameters": {
+            "from_value": {
+              "status_code": 301,
+              "target_url": {
+                "value": "$REDIRECT_URL"
+              },
+              "preserve_query_string": false
+            }
+          }
+        }
+      ]
+    }
+    EOF
+    )
+    
+    if [ -n "$EXISTING_RULE" ]; then
+      echo "Redirect rule already exists with ID: $EXISTING_RULE"
+      echo "Updating existing rule..."
+      
+      # Update existing ruleset
+      curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/rulesets/phases/http_request_redirect/entrypoint" \
+        -H "Authorization: Bearer $CF_API_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$RULE_CONFIG" | jq '.'
+    else
+      echo "Creating new redirect rule..."
+      
+      # Create new ruleset or add to existing
+      curl -s -X PUT "https://api.cloudflare.com/client/v4/zones/$ZONE_ID/rulesets/phases/http_request_redirect/entrypoint" \
+        -H "Authorization: Bearer $CF_API_TOKEN" \
+        -H "Content-Type: application/json" \
+        -d "$RULE_CONFIG" | jq '.'
+    fi
+    
+    echo "Redirect rule configuration completed successfully!"
+    echo "Domains $ZONE_NAME and www.$ZONE_NAME will now redirect to $REDIRECT_URL"

--- a/infra/gitops/resources/cloudflare-redirects/job.yaml
+++ b/infra/gitops/resources/cloudflare-redirects/job.yaml
@@ -1,0 +1,61 @@
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: cloudflare-redirect-setup
+  namespace: external-dns
+  labels:
+    app.kubernetes.io/name: cloudflare-redirects
+    app.kubernetes.io/part-of: platform
+  annotations:
+    argocd.argoproj.io/hook: Sync
+    argocd.argoproj.io/hook-delete-policy: BeforeHookCreation
+spec:
+  template:
+    metadata:
+      labels:
+        app.kubernetes.io/name: cloudflare-redirects
+    spec:
+      restartPolicy: OnFailure
+      containers:
+        - name: configure-redirects
+          image: alpine/curl:8.5.0
+          command: ["/bin/sh"]
+          args: ["/scripts/configure-redirects.sh"]
+          env:
+            - name: CF_API_TOKEN
+              valueFrom:
+                secretKeyRef:
+                  name: cloudflare-api-credentials
+                  key: api-token
+          volumeMounts:
+            - name: scripts
+              mountPath: /scripts
+              readOnly: true
+          resources:
+            limits:
+              cpu: 100m
+              memory: 128Mi
+            requests:
+              cpu: 50m
+              memory: 64Mi
+          securityContext:
+            runAsNonRoot: true
+            runAsUser: 65534
+            runAsGroup: 65534
+            allowPrivilegeEscalation: false
+            readOnlyRootFilesystem: true
+            capabilities:
+              drop:
+                - ALL
+      volumes:
+        - name: scripts
+          configMap:
+            name: cloudflare-redirect-script
+            defaultMode: 0755
+      securityContext:
+        fsGroup: 65534
+        seccompProfile:
+          type: RuntimeDefault
+  backoffLimit: 3
+  activeDeadlineSeconds: 300

--- a/infra/gitops/resources/cloudflare-redirects/kustomization.yaml
+++ b/infra/gitops/resources/cloudflare-redirects/kustomization.yaml
@@ -1,0 +1,12 @@
+---
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+resources:
+  - configmap.yaml
+  - job.yaml
+
+commonLabels:
+  app.kubernetes.io/name: cloudflare-redirects
+  app.kubernetes.io/component: configuration
+  app.kubernetes.io/part-of: platform


### PR DESCRIPTION
- Create Kubernetes Job to configure Cloudflare redirect rules via API
- Redirect 5dlabs.ai and www.5dlabs.ai to https://github.com/5dlabs
- Uses existing external-secrets Cloudflare API credentials
- Deploys to external-dns namespace alongside DNS management
- ArgoCD sync hooks ensure redirects are configured on deployment