### PR TITLE
fix: Update DMARC TXT record to use LoadBalancer service

### DIFF
--- a/infra/gitops/resources/sendgrid-dns/txt-records.yaml
+++ b/infra/gitops/resources/sendgrid-dns/txt-records.yaml
@@ -1,5 +1,6 @@
 ---
 # DMARC TXT record managed by external-dns
+# Using LoadBalancer service with TXT annotation
 apiVersion: v1
 kind: Service
 metadata:
@@ -7,13 +8,14 @@ metadata:
   namespace: external-dns
   annotations:
     external-dns.alpha.kubernetes.io/hostname: "_dmarc.5dlabs.ai"
-    external-dns.alpha.kubernetes.io/txt-records: "v=DMARC1; p=none;"
+    external-dns.alpha.kubernetes.io/txt-records: "\"v=DMARC1; p=none;\""
   labels:
     app.kubernetes.io/name: sendgrid-dns
     app.kubernetes.io/part-of: platform
 spec:
-  type: ClusterIP
-  clusterIP: None  # Headless service - no actual service, just DNS
+  type: LoadBalancer
   ports:
   - port: 80
     name: http
+  selector:
+    app: nonexistent  # No pods will match this selector


### PR DESCRIPTION
- Change from headless service to LoadBalancer for TXT record support
- Add proper TXT record annotation format with quotes
- Use nonexistent selector so no pods match (DNS-only service)