### PR TITLE
fix: Use working alpine/curl image and install jq

### DIFF
--- a/infra/gitops/resources/cloudflare-redirects/configmap.yaml
+++ b/infra/gitops/resources/cloudflare-redirects/configmap.yaml
@@ -9,8 +9,14 @@ metadata:
     app.kubernetes.io/part-of: platform
 data:
   configure-redirects.sh: |
-    #!/bin/bash
+    #!/bin/sh
     set -euo pipefail
+
+    # Install jq if not available
+    if ! command -v jq >/dev/null 2>&1; then
+      echo "Installing jq..."
+      apk add --no-cache jq
+    fi
 
     # Configuration
     ZONE_NAME="5dlabs.ai"

--- a/infra/gitops/resources/cloudflare-redirects/job.yaml
+++ b/infra/gitops/resources/cloudflare-redirects/job.yaml
@@ -19,8 +19,8 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: configure-redirects
-          image: dwdraju/alpine-curl-jq:3.18
-          command: ["/bin/bash"]
+          image: alpine/curl:8.5.0
+          command: ["/bin/sh"]
           args: ["/scripts/configure-redirects.sh"]
           env:
             - name: CF_API_TOKEN


### PR DESCRIPTION
- Replace non-existent dwdraju/alpine-curl-jq:3.18 with alpine/curl:8.5.0
- Install jq via apk in the script
- Use /bin/sh instead of /bin/bash for Alpine compatibility
- Remove trailing spaces