### PR TITLE
fix: Use alpine base image with root permissions for package installation

### DIFF
--- a/infra/gitops/resources/cloudflare-redirects/configmap.yaml
+++ b/infra/gitops/resources/cloudflare-redirects/configmap.yaml
@@ -12,11 +12,9 @@ data:
     #!/bin/sh
     set -euo pipefail
 
-    # Install jq if not available
-    if ! command -v jq >/dev/null 2>&1; then
-      echo "Installing jq..."
-      apk add --no-cache jq
-    fi
+    # Install required packages
+    echo "Installing curl and jq..."
+    apk update && apk add --no-cache curl jq
 
     # Configuration
     ZONE_NAME="5dlabs.ai"

--- a/infra/gitops/resources/cloudflare-redirects/job.yaml
+++ b/infra/gitops/resources/cloudflare-redirects/job.yaml
@@ -19,7 +19,7 @@ spec:
       restartPolicy: OnFailure
       containers:
         - name: configure-redirects
-          image: alpine/curl:8.5.0
+          image: alpine:3.19
           command: ["/bin/sh"]
           args: ["/scripts/configure-redirects.sh"]
           env:
@@ -40,11 +40,10 @@ spec:
               cpu: 50m
               memory: 64Mi
           securityContext:
-            runAsNonRoot: true
-            runAsUser: 65534
-            runAsGroup: 65534
+            runAsUser: 0
+            runAsGroup: 0
             allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
+            readOnlyRootFilesystem: false
             capabilities:
               drop:
                 - ALL
@@ -54,7 +53,7 @@ spec:
             name: cloudflare-redirect-script
             defaultMode: 0755
       securityContext:
-        fsGroup: 65534
+        fsGroup: 0
         seccompProfile:
           type: RuntimeDefault
   backoffLimit: 3


### PR DESCRIPTION
- Change to alpine:3.19 base image to avoid image pull issues
- Run as root user (0) to allow apk package installation
- Install both curl and jq via apk in script
- Set readOnlyRootFilesystem: false to allow package installation
- This is acceptable for a one-time configuration job