### PR TITLE
feat(mailu): Configure SendGrid SMTP relay for outbound email

### DIFF
--- a/infra/gitops/applications/mailu.yaml
+++ b/infra/gitops/applications/mailu.yaml
@@ -148,6 +148,23 @@ spec:
             limits:
               memory: "512Mi"
               cpu: "500m"
+          # Configure SMTP relay through SendGrid
+          extraEnvVars:
+            - name: RELAYHOST
+              valueFrom:
+                secretKeyRef:
+                  name: mailu-secret
+                  key: RELAYHOST
+            - name: RELAYUSER
+              valueFrom:
+                secretKeyRef:
+                  name: mailu-secret
+                  key: RELAYUSER
+            - name: RELAYPASSWORD
+              valueFrom:
+                secretKeyRef:
+                  name: mailu-secret
+                  key: RELAYPASSWORD
 
         dovecot:
           enabled: true

--- a/infra/secret-store/mailu-external-secrets.yaml
+++ b/infra/secret-store/mailu-external-secrets.yaml
@@ -20,6 +20,10 @@ spec:
         secret-key: "{{ .secretkey }}"
         # Add the database password from PostgreSQL secret
         DB_PW: "{{ .dbpassword }}"
+        # SendGrid SMTP relay credentials
+        RELAYHOST: "smtp.sendgrid.net"
+        RELAYUSER: "apikey"
+        RELAYPASSWORD: "{{ .sendgridapikey }}"
   data:
   - secretKey: secretkey
     remoteRef:
@@ -29,3 +33,7 @@ spec:
     remoteRef:
       key: mailu-config  
       property: db_password
+  - secretKey: sendgridapikey
+    remoteRef:
+      key: mailu-config
+      property: sendgrid_api_key


### PR DESCRIPTION
- Add SendGrid credentials to mailu-external-secrets
- Configure Postfix to use SMTP relay via environment variables
- Bypasses ISP port 25 blocking for outbound email delivery
- SendGrid API key added to secret-store/mailu-config secret