### PR TITLE
fix: prevent duplicate workflow triggers by setting sensor replicas to 1

### DIFF
--- a/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
@@ -6,7 +6,12 @@ metadata:
   name: play-workflow-pr-merged
   namespace: argo
 spec:
-  replicas: 2
+  replicas: 1
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     serviceAccountName: argo-events-sa
   dependencies:

--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -6,7 +6,12 @@ metadata:
   name: play-workflow-pr-created
   namespace: argo
 spec:
-  replicas: 2
+  replicas: 1
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     serviceAccountName: argo-events-sa
   dependencies:
@@ -140,7 +145,12 @@ metadata:
   name: play-workflow-ready-for-qa
   namespace: argo
 spec:
-  replicas: 2
+  replicas: 1
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     serviceAccountName: argo-events-sa
   dependencies:
@@ -367,7 +377,12 @@ metadata:
   name: implementation-agent-remediation
   namespace: argo
 spec:
-  replicas: 2
+  replicas: 1
+  deploymentStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   template:
     serviceAccountName: argo-events-sa
   dependencies:


### PR DESCRIPTION
- Set all Argo Events sensors to use single replica to prevent duplicate event processing
- Add RollingUpdate deployment strategy with maxUnavailable=0 for zero-downtime updates
- Affects play-workflow-pr-created, play-workflow-ready-for-qa, play-workflow-pr-merged, and implementation-agent-remediation sensors

This fixes the issue where multiple Rex/Cleo/Tess jobs were being triggered for the same task due to multiple sensor replicas processing the same GitHub webhook events simultaneously.