### PR TITLE
Fix/duplicate-workflow-creation

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -476,6 +476,7 @@ spec:
               service: "{{`{{workflow.parameters.service}}`}}"
               github-app: "{{`{{inputs.parameters.github-app}}`}}"
               workflow-name: "{{`{{workflow.name}}`}}"
+              workflow-run: "{{`{{workflow.name}}`}}"
               workflow-stage: "{{`{{inputs.parameters.stage}}`}}"
               workflow-type: "play-orchestration"
           spec:
@@ -499,6 +500,7 @@ spec:
               WORKFLOW_STAGE: "{{`{{inputs.parameters.stage}}`}}"
               WORKFLOW_NAME: "{{`{{workflow.name}}`}}"
               SERVICE_NAME: "{{`{{workflow.parameters.service}}`}}"
+              RUN_NAME: "{{`{{workflow.name}}`}}"
 
     # Helper to reliably resolve the created CodeRun name before waiting for completion
     - name: resolve-coderun-name

--- a/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
@@ -212,8 +212,16 @@ spec:
                           EXISTING_OWNER=$(kubectl get configmap $LOCK_NAME -n agent-platform \
                             -o jsonpath='{.data.owner}' 2>/dev/null || echo "unknown")
                           LOCK_TIME=$(kubectl get configmap $LOCK_NAME -n agent-platform \
-                            -o jsonpath='{.data.timestamp}' 2>/dev/null || echo "0")
+                            -o jsonpath='{.data.timestamp}' 2>/dev/null || echo "")
                           CURRENT_TIME=$(date -u +%s)
+
+                          # If lock time is invalid or missing, assume it's recent (don't delete it)
+                          if [ -z "$LOCK_TIME" ] || ! [[ "$LOCK_TIME" =~ ^[0-9]+$ ]]; then
+                            echo "⚠️ PR #$PR_NUMBER is already being processed by: $EXISTING_OWNER"
+                            echo "Lock exists but timestamp is invalid, treating as valid lock"
+                            exit 0
+                          fi
+
                           LOCK_AGE=$((CURRENT_TIME - LOCK_TIME))
 
                           if [ $LOCK_AGE -gt 3600 ]; then


### PR DESCRIPTION
- Add RUN_NAME environment variable to CodeRun spec
- Add workflow-run label to CodeRun metadata
- This fixes Rex labeling PRs with 'run-unknown' instead of the actual workflow name