### PR TITLE
fix: kubectl JSONPath negative indexing bug

### DIFF
--- a/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
@@ -591,10 +591,11 @@ spec:
 
                         # Retrieve parameters from the current task's workflow
                         echo "🔍 Looking for current task workflow to retrieve parameters..."
+                        # Get the most recent workflow for this task (sorted by creation time, take last one)
                         CURRENT_WORKFLOW=$(kubectl get workflows -n agent-platform \
                           -l task-id=$TASK_ID,workflow-type=play-orchestration \
                           --sort-by='.metadata.creationTimestamp' \
-                          -o jsonpath='{.items[-1:].metadata.name}' 2>/dev/null || echo "")
+                          -o jsonpath='{range .items[*]}{.metadata.name}{"\n"}{end}' 2>/dev/null | tail -n1)
 
                         if [ -z "$CURRENT_WORKFLOW" ]; then
                           echo "⚠️ Could not find workflow for task $TASK_ID, using defaults"


### PR DESCRIPTION
- Replace non-standard negative array indexing [-1:] with standard approach
- Use 'range .items[*]' to output all names, then pipe to 'tail -n1'
- This ensures compatibility across all kubectl versions
- Fixes parameter persistence falling back to defaults

Bug identified by cursor bot - kubectl's JSONPath doesn't support
negative indexing, causing workflow retrieval to fail silently