### PR TITLE
Feat/workflow-parameter-persistence

### DIFF
--- a/cto-config.json
+++ b/cto-config.json
@@ -28,7 +28,7 @@
       "qualityAgent": "5DLabs-Cleo",
       "testingAgent": "5DLabs-Tess",
       "repository": "5dlabs/cto-play-test",
-      "service": "cto",
+      "service": "cto-play-test",
       "docsRepository": "5dlabs/cto-play-test",
       "docsProjectDirectory": "docs"
     }

--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -31,7 +31,9 @@ spec:
           "quality-agent": "{{`{{workflow.parameters.quality-agent}}`}}",
           "testing-agent": "{{`{{workflow.parameters.testing-agent}}`}}",
           "repository": "{{`{{workflow.parameters.repository}}`}}",
-          "service": "{{`{{workflow.parameters.service}}`}}"
+          "service": "{{`{{workflow.parameters.service}}`}}",
+          "docs-repository": "{{`{{workflow.parameters.docs-repository}}`}}",
+          "docs-project-directory": "{{`{{workflow.parameters.docs-project-directory}}`}}"
         }
 
   # Main entry point
@@ -61,6 +63,12 @@ spec:
       - name: service
         description: "Service identifier for persistent workspace"
         value: "play-test"
+      - name: docs-repository
+        description: "GitHub repository containing documentation"
+        value: "5dlabs/cto-play-test"
+      - name: docs-project-directory
+        description: "Directory within docs repository containing project documentation"
+        value: "docs"
 
       # Model configuration
       - name: model

--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -494,8 +494,8 @@ spec:
             taskId: {{`{{inputs.parameters.task-id}}`}}
             service: "{{`{{workflow.parameters.service}}`}}"
             repositoryUrl: "{{`{{workflow.parameters.repository}}`}}"
-            docsRepositoryUrl: "https://github.com/5dlabs/cto-play-test"
-            docsProjectDirectory: "docs"
+            docsRepositoryUrl: "https://github.com/{{`{{workflow.parameters.docs-repository}}`}}"
+            docsProjectDirectory: "{{`{{workflow.parameters.docs-project-directory}}`}}"
             workingDirectory: "."
             githubApp: "{{`{{inputs.parameters.github-app}}`}}"
             model: "{{`{{workflow.parameters.model}}`}}"

--- a/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
@@ -604,6 +604,8 @@ spec:
                           IMPL_AGENT="5DLabs-Rex"
                           QUALITY_AGENT="5DLabs-Cleo"
                           TESTING_AGENT="5DLabs-Tess"
+                          DOCS_REPO="$REPO_PATH"  # Default to same as main repository
+                          DOCS_DIR="docs"
                         else
                           echo "✅ Found workflow: $CURRENT_WORKFLOW"
 
@@ -617,6 +619,8 @@ spec:
                             IMPL_AGENT="5DLabs-Rex"
                             QUALITY_AGENT="5DLabs-Cleo"
                             TESTING_AGENT="5DLabs-Tess"
+                            DOCS_REPO="$REPO_PATH"  # Default to same as main repository
+                            DOCS_DIR="docs"
                           else
                             echo "📦 Retrieved parameters from workflow annotation"
                             # Parse individual parameters with fallbacks
@@ -628,12 +632,25 @@ spec:
                             # Update repository and service if they were stored
                             STORED_REPO=$(echo "$INITIAL_PARAMS" | jq -r '.repository // ""')
                             STORED_SERVICE=$(echo "$INITIAL_PARAMS" | jq -r '.service // ""')
+                            STORED_DOCS_REPO=$(echo "$INITIAL_PARAMS" | jq -r '."docs-repository" // ""')
+                            STORED_DOCS_DIR=$(echo "$INITIAL_PARAMS" | jq -r '."docs-project-directory" // "docs"')
 
                             if [ -n "$STORED_REPO" ] && [ "$STORED_REPO" != "null" ]; then
                               REPO_PATH="$STORED_REPO"
                             fi
                             if [ -n "$STORED_SERVICE" ] && [ "$STORED_SERVICE" != "null" ]; then
                               SERVICE_NAME="$STORED_SERVICE"
+                            fi
+                            if [ -n "$STORED_DOCS_REPO" ] && [ "$STORED_DOCS_REPO" != "null" ]; then
+                              DOCS_REPO="$STORED_DOCS_REPO"
+                            else
+                              # Default to same as main repository if not specified
+                              DOCS_REPO="$REPO_PATH"
+                            fi
+                            if [ -n "$STORED_DOCS_DIR" ] && [ "$STORED_DOCS_DIR" != "null" ]; then
+                              DOCS_DIR="$STORED_DOCS_DIR"
+                            else
+                              DOCS_DIR="docs"
                             fi
                           fi
                         fi
@@ -645,6 +662,8 @@ spec:
                         echo "  Testing Agent: $TESTING_AGENT"
                         echo "  Repository: $REPO_PATH"
                         echo "  Service: $SERVICE_NAME"
+                        echo "  Docs Repository: $DOCS_REPO"
+                        echo "  Docs Project Directory: $DOCS_DIR"
 
                         # Create the next task workflow using the WorkflowTemplate
                         cat <<EOF | kubectl create -f -
@@ -667,7 +686,9 @@ spec:
                                 "quality-agent": "$QUALITY_AGENT",
                                 "testing-agent": "$TESTING_AGENT",
                                 "repository": "$REPO_PATH",
-                                "service": "$SERVICE_NAME"
+                                "service": "$SERVICE_NAME",
+                                "docs-repository": "$DOCS_REPO",
+                                "docs-project-directory": "$DOCS_DIR"
                               }
                         spec:
                           workflowTemplateRef:
@@ -689,9 +710,9 @@ spec:
                               - name: testing-agent
                                 value: "$TESTING_AGENT"
                               - name: docs-repository
-                                value: "$REPO_PATH"
+                                value: "$DOCS_REPO"
                               - name: docs-project-directory
-                                value: "docs"
+                                value: "$DOCS_DIR"
                         EOF
 
                         if [ $? -eq 0 ]; then

--- a/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
@@ -688,6 +688,10 @@ spec:
                                 value: "$QUALITY_AGENT"
                               - name: testing-agent
                                 value: "$TESTING_AGENT"
+                              - name: docs-repository
+                                value: "$REPO_PATH"
+                              - name: docs-project-directory
+                                value: "docs"
                         EOF
 
                         if [ $? -eq 0 ]; then


### PR DESCRIPTION
- Store docs-repository and docs-project-directory in workflow annotations
- Retrieve and forward these parameters when creating next task
- Use parameters in workflow template instead of hardcoded values
- Add proper defaults when parameters are missing
- This ensures GitHub authentication works correctly for all tasks in the chain