### PR TITLE
feat: add requirements.yaml support to play workflow

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -93,6 +93,11 @@ spec:
       - name: merge-sha
         description: "Merge commit SHA (populated after PR merge)"
         value: ""
+      
+      # Task requirements (secrets and environment variables)
+      - name: task-requirements
+        description: "Base64-encoded requirements.yaml content for all agents"
+        value: ""
 
   # Workflow instance naming pattern
   onExit: cleanup-handler
@@ -511,6 +516,8 @@ spec:
             overwriteMemory: false
             docsBranch: "main"
             contextVersion: 1
+            # Pass task requirements if available
+            taskRequirements: "{{`{{workflow.parameters.task-requirements}}`}}"
             # Pass PR context as environment if available
             env:
               PR_URL: "{{`{{inputs.parameters.pr-url}}`}}"

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -1011,7 +1011,19 @@ fn handle_play_workflow(arguments: &HashMap<String, Value>) -> Result<Value> {
     eprintln!("🐛 DEBUG: Quality agent: {quality_agent}");
     eprintln!("🐛 DEBUG: Testing agent: {testing_agent}");
 
-    let params = vec![
+    // Check for requirements.yaml file
+    let workspace_dir = std::env::current_dir().context("Failed to get current directory")?;
+    let docs_dir = workspace_dir.join(&docs_project_directory);
+    let task_requirements_path = docs_dir.join(format!("task-{task_id}/requirements.yaml"));
+    let project_requirements_path = docs_dir.join("requirements.yaml");
+    
+    eprintln!(
+        "🔍 Checking for requirements.yaml in: {} (docs_project_directory='{}')",
+        docs_dir.display(),
+        docs_project_directory
+    );
+    
+    let mut params = vec![
         format!("task-id={task_id}"),
         format!("repository={repository}"),
         format!("service={service}"),
@@ -1022,6 +1034,32 @@ fn handle_play_workflow(arguments: &HashMap<String, Value>) -> Result<Value> {
         format!("testing-agent={testing_agent}"),
         format!("model={model}"),
     ];
+
+    // Load and encode requirements.yaml if it exists
+    let requirements_path = if task_requirements_path.exists() {
+        eprintln!("📋 Found task-specific requirements.yaml for task {task_id}");
+        Some(task_requirements_path)
+    } else if project_requirements_path.exists() {
+        eprintln!("📋 Found project-level requirements.yaml");
+        Some(project_requirements_path)
+    } else {
+        eprintln!("ℹ️ No requirements.yaml found");
+        None
+    };
+
+    if let Some(path) = requirements_path {
+        let requirements_content = std::fs::read_to_string(&path)
+            .context(format!("Failed to read requirements file: {}", path.display()))?;
+        
+        // Base64 encode the requirements
+        use base64::{engine::general_purpose, Engine as _};
+        let encoded = general_purpose::STANDARD.encode(requirements_content);
+        params.push(format!("task-requirements={encoded}"));
+        eprintln!("✅ Encoded requirements.yaml for workflow");
+    } else {
+        // Always provide task-requirements parameter, even if empty (Argo requires it)
+        params.push("task-requirements=".to_string());
+    }
 
     let mut args = vec![
         "submit",


### PR DESCRIPTION
- Add task-requirements parameter to play workflow template
- Pass taskRequirements to CodeRun specs for all agents (Rex, Cleo, Tess)
- Update MCP server to detect and encode requirements.yaml for play command
- Support task-specific and project-level requirements.yaml files
- Ensure all agents in a play workflow share the same environment variables and secrets