### PR TITLE
Fix/cleo-with-reqs

### DIFF
--- a/controller/src/tasks/code/resources.rs
+++ b/controller/src/tasks/code/resources.rs
@@ -962,7 +962,7 @@ impl<'a> CodeResourceManager<'a> {
 
         // Process legacy env_from_secrets if present (regardless of task requirements)
         for secret_env in &code_run.spec.env_from_secrets {
-                env_vars.push(json!({
+            env_vars.push(json!({
                     "name": &secret_env.name,
                     "valueFrom": {
                         "secretKeyRef": {


### PR DESCRIPTION
- Always process spec.env vars first, before requirements.yaml
- Move spec.env processing outside of the else branch
- Protect PR_URL and PR_NUMBER from being overridden by requirements
- Re-add PR context vars after critical system vars
- Fix bug where Cleo and Tess couldn't see PR info when requirements.yaml was present

This fixes the issue where Cleo couldn't add labels or comments to PRs in single-repo setups with requirements.yaml