### PR TITLE
fix(intake): revert to correct Claude image with Claude Code pre-installed

### DIFF
--- a/infra/charts/controller/templates/project-intake-template.yaml
+++ b/infra/charts/controller/templates/project-intake-template.yaml
@@ -126,7 +126,7 @@ spec:
         parameters:
         - name: configmap-name
       container:
-        image: ghcr.io/5dlabs/claude-code:{{ .Values.agent.image.tag | default "latest" }}
+        image: {{ .Values.agent.image.repository }}:{{ .Values.agent.image.tag | default "latest" }}
         imagePullPolicy: {{ .Values.agent.image.pullPolicy | default "Always" }}
         command: ["/bin/bash"]
         args: ["/claude-templates/intake_intake.sh"]


### PR DESCRIPTION
- Use ghcr.io/5dlabs/claude:latest (has @anthropic-ai/claude-code installed)
- Remove non-existent ghcr.io/5dlabs/claude-code image reference