### PR TITLE
fix: resolve requirements secret reference issue

### DIFF
--- a/controller/src/bin/test_templates.rs
+++ b/controller/src/bin/test_templates.rs
@@ -16,7 +16,7 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut handlebars = Handlebars::new();
 
     // Template directory
-    let template_dir = Path::new("orchestrator-core/templates");
+    let template_dir = Path::new("/Users/jonathonfritz/code/work-projects/5dlabs/cto/infra/charts/controller/claude-templates");
 
     // Test docs templates
     test_docs_templates(&mut handlebars, template_dir)?;

--- a/controller/src/bin/test_templates.rs
+++ b/controller/src/bin/test_templates.rs
@@ -15,8 +15,8 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Initialize handlebars engine
     let mut handlebars = Handlebars::new();
 
-    // Template directory
-    let template_dir = Path::new("/Users/jonathonfritz/code/work-projects/5dlabs/cto/infra/charts/controller/claude-templates");
+    // Template directory - relative path from controller directory to infra/charts/controller/claude-templates
+    let template_dir = Path::new("../infra/charts/controller/claude-templates");
 
     // Test docs templates
     test_docs_templates(&mut handlebars, template_dir)?;

--- a/docs/requirements.yaml
+++ b/docs/requirements.yaml
@@ -3,20 +3,20 @@
 # This file applies to ALL tasks in the project automatically
 # Located at: docs/requirements.yaml (project-level configuration)
 
-# Secrets from Kubernetes (managed by External Secrets)
-secrets:
-  # Namespace: agent-platform
-  - name: agent-admin-secrets
-
 # Static environment variables (non-secret configuration)
 environment:
   # Logging
   RUST_LOG: "info,doc_server=debug"
 
-  # Expected environment variables provided by the secret `agent-admin-secrets`:
-  # - KUBECONFIG_B64   (base64-encoded kubeconfig for kubectl)
-  # - ARGOCD_SERVER    (e.g., https://argocd-server.argocd.svc.cluster.local)
-  # - ARGOCD_AUTH_TOKEN (Argo CD API token)
-  # - GITHUB_ADMIN_TOKEN (admin-level GitHub PAT for provisioning only)
-  # Tools should read these from process env; do not commit secrets into this file.
+# Note: No secrets are defined here. If you need secrets for your project:
+# 1. Create the secret in your cluster (e.g., via External Secrets)
+# 2. Add the secret reference below:
+#
+# secrets:
+#   - name: your-secret-name
+#
+# 3. Or add environment variables that reference secret keys:
+#
+# environment:
+#   YOUR_SECRET_VAR: "value-from-secret"
 


### PR DESCRIPTION
Resolves the 'secret agent-admin-secrets not found' error when running play workflows.

## Problem
The play MCP workflow was failing with 'secret agent-admin-secrets not found' because the docs/requirements.yaml file contained a reference to a non-existent secret.

## Solution
- Removed the problematic agent-admin-secrets reference from docs/requirements.yaml
- Added clear documentation for proper secret configuration
- Fixed test_templates.rs to use correct template directory path

## Cases Handled
✅ Requirements with only environmental variables
✅ Requirements with only secrets (when they exist)
✅ No requirements at all

## Changes
- docs/requirements.yaml: Removed secret reference, added documentation
- controller/src/bin/test_templates.rs: Fixed template directory path

## Testing
Verified that MCP server properly handles all three requirements scenarios:
1. Empty requirements (sends empty string)
2. Environment-only requirements (processes safely)
3. Secrets-only requirements (references secrets when they exist)