### PR TITLE
fix: properly escape GitHub Actions variables in heredoc

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
@@ -676,7 +676,7 @@ CLEO_PROMPT="$CLEO_PROMPT
 
    env:
      REGISTRY: ghcr.io
-     IMAGE_BASE: \\\$\\\{\\{ github.repository_owner \\\}\\\}
+     IMAGE_BASE: \\\${{\\{ github.repository_owner \\\}}}
 
    jobs:
      build:
@@ -689,16 +689,16 @@ CLEO_PROMPT="$CLEO_PROMPT
          - name: Build binary
            env:
              RUSTC_WRAPPER: "sccache"
-             CARGO_TARGET_DIR: "\\\$HOME/cache/target"
+             CARGO_TARGET_DIR: "$HOME/cache/target"
            run: |
              cargo build --release
-             cp \\\$HOME/cache/target/release/<binary> ./<binary>
+             cp \$HOME/cache/target/release/<binary> ./<binary>
          - uses: docker/setup-buildx-action@v3
          - uses: docker/login-action@v3
            with:
              registry: ghcr.io
-             username: \\\$\\\{\\{ github.actor \\\}\\\}
-             password: \\\$\\\{\\{ secrets.GITHUB_TOKEN \\\}\\\}
+             username: \\\${{\\{ github.actor \\\}}}
+             password: \\\${{\\{ secrets.GITHUB_TOKEN \\\}}}
          - uses: docker/build-push-action@v5
            with:
              context: .
@@ -706,8 +706,8 @@ CLEO_PROMPT="$CLEO_PROMPT
              platforms: linux/amd64,linux/arm64
              push: true
              tags: |
-               ghcr.io/\\\$\\\{\\{ github.repository \\\}\\\}:latest
-               ghcr.io/\\\$\\\{\\{ github.repository \\\}\\\}:\\\$\\\{\\{ github.sha \\\}\\\}
+               ghcr.io/\\\${{\\{ github.repository \\\}}}:latest
+               ghcr.io/\\\${{\\{ github.repository \\\}}}:\\\${{\\{ github.sha \\\}}}
              cache-from: type=gha
              cache-to: type=gha,mode=max
    \\\`\\\`\\\`


### PR DESCRIPTION
- Fix GitHub Actions template variables being interpreted by shell
- Escape \$ for variables like \${{\{ github.repository \\}}}
- This prevents shell from trying to interpret \${{\{ \\}}} syntax as commands
- Resolves the 'fix: command not found' error at line 709

The issue was that GitHub Actions variables like \${{\{ github.repository \\}}} contain \$ which the shell interprets as variable substitution, even inside heredoc. These need to be escaped to prevent shell interpretation.