### PR TITLE
fix: correct variable escaping inconsistencies in Cleo template

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
@@ -676,7 +676,7 @@ CLEO_PROMPT="$CLEO_PROMPT
 
    env:
      REGISTRY: ghcr.io
-     IMAGE_BASE: \\\${{\\{ github.repository_owner \\\}}}
+     IMAGE_BASE: \\\$\\\{\\{ github.repository_owner \\\}\\\}
 
    jobs:
      build:
@@ -689,7 +689,7 @@ CLEO_PROMPT="$CLEO_PROMPT
          - name: Build binary
            env:
              RUSTC_WRAPPER: "sccache"
-             CARGO_TARGET_DIR: "$HOME/cache/target"
+             CARGO_TARGET_DIR: "\$HOME/cache/target"
            run: |
              cargo build --release
              cp \$HOME/cache/target/release/<binary> ./<binary>
@@ -697,8 +697,8 @@ CLEO_PROMPT="$CLEO_PROMPT
          - uses: docker/login-action@v3
            with:
              registry: ghcr.io
-             username: \\\${{\\{ github.actor \\\}}}
-             password: \\\${{\\{ secrets.GITHUB_TOKEN \\\}}}
+             username: \\\$\\\{\\{ github.actor \\\}\\\}
+             password: \\\$\\\{\\{ secrets.GITHUB_TOKEN \\\}\\\}
          - uses: docker/build-push-action@v5
            with:
              context: .
@@ -706,8 +706,8 @@ CLEO_PROMPT="$CLEO_PROMPT
              platforms: linux/amd64,linux/arm64
              push: true
              tags: |
-               ghcr.io/\\\${{\\{ github.repository \\\}}}:latest
-               ghcr.io/\\\${{\\{ github.repository \\\}}}:\\\${{\\{ github.sha \\\}}}
+               ghcr.io/\\\$\\\{\\{ github.repository \\\}\\\}:latest
+               ghcr.io/\\\$\\\{\\{ github.repository \\\}\\\}:\\\$\\\{\\{ github.sha \\\}\\\}
              cache-from: type=gha
              cache-to: type=gha,mode=max
    \\\`\\\`\\\`


### PR DESCRIPTION
- Fix CARGO_TARGET_DIR escaping: use \$HOME consistently in both env var and cp command
- Fix GitHub Actions variable escaping: use proper \$\\{\\{ syntax instead of over-escaped versions
- Resolve path mismatch between env var expansion and command execution
- Ensure YAML syntax is correct for GitHub Actions workflows

Addresses the issues identified in PR #557 discussion where variable escaping was inconsistent and causing malformed YAML.