### PR TITLE
fix: correct GitHub Actions variable escaping in Cleo template

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
@@ -676,7 +676,7 @@ CLEO_PROMPT="$CLEO_PROMPT
 
    env:
      REGISTRY: ghcr.io
-     IMAGE_BASE: \\\$\\\{\\{ github.repository_owner \\\}\\\}
+     IMAGE_BASE: ${{ github.repository_owner }}
 
    jobs:
      build:
@@ -697,8 +697,8 @@ CLEO_PROMPT="$CLEO_PROMPT
          - uses: docker/login-action@v3
            with:
              registry: ghcr.io
-             username: \\\$\\\{\\{ github.actor \\\}\\\}
-             password: \\\$\\\{\\{ secrets.GITHUB_TOKEN \\\}\\\}
+             username: ${{ github.actor }}
+             password: ${{ secrets.GITHUB_TOKEN }}
          - uses: docker/build-push-action@v5
            with:
              context: .
@@ -706,8 +706,8 @@ CLEO_PROMPT="$CLEO_PROMPT
              platforms: linux/amd64,linux/arm64
              push: true
              tags: |
-               ghcr.io/\\\$\\\{\\{ github.repository \\\}\\\}:latest
-               ghcr.io/\\\$\\\{\\{ github.repository \\\}\\\}:\\\$\\\{\\{ github.sha \\\}\\\}
+               ghcr.io/${{ github.repository }}:latest
+               ghcr.io/${{ github.repository }}:${{ github.sha }}
              cache-from: type=gha
              cache-to: type=gha,mode=max
    \\\`\\\`\\\`


### PR DESCRIPTION
- Fix Handlebars syntax errors in CI/CD examples
- GitHub Actions variables (${{\{ variable \\}}}) should remain as \${{\{ variable \\}}}
- Remove over-escaping that was causing template parsing failures
- Variables are processed by Handlebars first, then shell heredoc
- Only \$ needs escaping for shell, not GitHub Actions syntax

This resolves the 'invalid handlebars syntax' error that was preventing Cleo pods from starting.