### PR TITLE
fix: remove ASCII art from Tess template to resolve cache_control errors

### DIFF
--- a/infra/charts/controller/claude-templates/code/container-tess.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-tess.sh.hbs
@@ -729,29 +729,16 @@ You are Tess - the quality gatekeeper for **Task $TASK_ID ONLY**. Your job is to
 - BE BRUTALLY HONEST - don't spare feelings
 
 **YOUR WORKFLOW LOOP (MUST COMPLETE)**:
-+------------------+
-| Check CI Status  |<--------------+
-+--------+---------+               |
-         |                         |
-    CI Passing?                    |
-         +-No-> Write/Fix Tests -->|
-         |                         |
-    Write Tests                    |
-         |                         |
-    Check Coverage                 |
-         +-<95%-> Add More Tests ->|
-         |                         |
-    Deploy to K8s                  |
-         +-Failed-> Fix Issues --->|
-         |                         |
-    All Criteria Met?              |
-         +-No-> Fix Issues ------->|
-         |                         |
-    POST APPROVE                   |
-         |                         |
-    EXIT (ONLY HERE)          
+1. Check CI Status
+2. If CI fails: Write/Fix Tests and retry
+3. Write comprehensive tests
+4. Check test coverage (must be >= 95%)
+5. Deploy to Kubernetes (if access available)
+6. Verify all acceptance criteria met
+7. If issues found: Fix them and retry
+8. Post APPROVE review (only when everything passes)
 
-Your STRICT testing requirements:
+**Your STRICT testing requirements:**
 
 1. **CRITICAL: Verify CI Status FIRST (ABSOLUTE BLOCKER)**:
    - **If repository has workflows**: Run \`gh pr checks $PR_NUM\` to see CI status


### PR DESCRIPTION
This PR removes the ASCII art box-drawing characters from Tess's INITIAL_GUIDANCE that were causing cache_control API errors.

## Problem
Tess was failing with:
- `cache_control cannot be set for empty text blocks` API error
- `fix: command not found` shell parsing issues
- Complex ASCII art was causing JSON processing problems

## Solution
- Removed ASCII art box drawing characters from workflow loop diagram
- Replaced with clean numbered list format
- Prevents JSON parsing issues that create empty text blocks
- Improves shell script reliability and readability

## Testing
This fix should resolve the cache_control errors and allow Tess to execute properly in the workflow orchestration system.