### PR TITLE
fix(intake): update model configuration to use proper Claude model name

### DIFF
--- a/cto-config.json
+++ b/cto-config.json
@@ -8,7 +8,7 @@
       "sourceBranch": "main"
     },
     "intake": {
-      "model": "opus",
+      "model": "claude-opus-4-1-20250805",
       "githubApp": "5DLabs-Morgan"
     },
     "code": {


### PR DESCRIPTION
Fixes Claude Code API failures in intake workflow by updating model configuration.

## Problem
Intake workflow was failing with Claude Code API errors because the model was configured as 'opus' instead of a proper Claude model name.

## Solution  
- Updated intake model from 'opus' to 'claude-opus-4-1-20250805'
- Aligned with other services using full model names
- Should resolve Claude Code API call failures

## Testing
The previous intake test showed the workflow progressing past model configuration but failing on Claude Code API calls. This fix should resolve that issue.

## Related
Follows the same pattern as docs and code services in cto-config.json.