### PR TITLE
fix(intake): update model configuration to use proper Claude model name

### DIFF
--- a/cto-config.json
+++ b/cto-config.json
@@ -8,7 +8,7 @@
       "sourceBranch": "main"
     },
     "intake": {
-      "model": "opus",
+      "model": "claude-opus-4-1-20250805",
       "githubApp": "5DLabs-Morgan"
     },
     "code": {


### PR DESCRIPTION
- Change intake model from 'opus' to 'claude-opus-4-1-20250805'
- Align with other services using full model names
- Fix Claude Code API call failures