### PR TITLE
fix(intake): update TaskMaster rules to include Claude and Cursor roles

### DIFF
--- a/infra/charts/controller/claude-templates/intake/intake.sh
+++ b/infra/charts/controller/claude-templates/intake/intake.sh
@@ -331,7 +331,7 @@ echo "🔍 Attempting TaskMaster init with full flags..."
     --name "$PROJECT_NAME" \
     --description "Auto-generated project from intake pipeline" \
     --version "0.1.0" \
-    --rules "claude" \
+    --rules "claude,cursor" \
     --skip-install \
     --aliases
 INIT_EXIT_CODE=$?


### PR DESCRIPTION
- Update TaskMaster initialization to use --rules 'claude,cursor'
- Ensures only Claude and Cursor AI assistant rules are included
- Removes other AI provider rules as requested