### PR TITLE
fix: Use 'in' comparator instead of unsupported regex '~' comparator

### DIFF
--- a/infra/gitops/resources/github-webhooks/remediation-feedback-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/remediation-feedback-sensor.yaml
@@ -41,8 +41,8 @@ spec:
           # Filter for comments containing '🔴 Required Changes' pattern
           - path: body.comment.body
             type: string
-            comparator: "~"
-            value: [".*🔴 Required Changes.*"]
+            comparator: "in"
+            value: ["🔴 Required Changes"]
           # Ensure comment is on a pull request (not issue)
           - path: body.issue.pull_request.url
             type: string


### PR DESCRIPTION
- Argo Events v1.9.7 doesn't support regex matching with '~'
- Changed to 'in' comparator for substring matching of '🔴 Required Changes'