### PR TITLE
fix: add missing RoleBinding for argo-workflow ServiceAccount

### DIFF
--- a/infra/gitops/rbac/argo-workflow-permissions.yaml
+++ b/infra/gitops/rbac/argo-workflow-permissions.yaml
@@ -1,0 +1,32 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-workflow-agent-platform-binding
+  namespace: agent-platform
+  annotations:
+    description: "Allows argo-workflow ServiceAccount from argo namespace to patch workflows in agent-platform namespace for Play workflow resumption"
+subjects:
+- kind: ServiceAccount
+  name: argo-workflow
+  namespace: argo
+roleRef:
+  kind: Role
+  name: argo-events-workflows-agent-platform
+  apiGroup: rbac.authorization.k8s.io
+---
+# Also ensure argo-workflow can access workflows in its own namespace
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-workflow-argo-namespace-binding
+  namespace: argo
+  annotations:
+    description: "Allows argo-workflow ServiceAccount to manage workflows in argo namespace"
+subjects:
+- kind: ServiceAccount
+  name: argo-workflow
+  namespace: argo
+roleRef:
+  kind: ClusterRole
+  name: argo-workflow
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- Play workflow sensor creates resume workflows with argo-workflow SA
- Resume workflows need to patch suspended workflow nodes in agent-platform
- This was preventing automatic Tess startup after ready-for-qa label
- Added proper RBAC permissions for cross-namespace workflow management