### PR TITLE
feat: add RoleBinding for argo-workflow ServiceAccount in agent-platform

### DIFF
--- a/infra/gitops/rbac/argo-workflow-permissions.yaml
+++ b/infra/gitops/rbac/argo-workflow-permissions.yaml
@@ -31,3 +31,20 @@ roleRef:
   kind: ClusterRole
   name: argo-workflow
   apiGroup: rbac.authorization.k8s.io
+---
+# Allow argo-workflow SA in agent-platform to create CodeRuns locally
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: argo-workflow-local-binding
+  namespace: agent-platform
+  annotations:
+    description: "Allows argo-workflow ServiceAccount in agent-platform namespace to create CodeRuns"
+subjects:
+- kind: ServiceAccount
+  name: argo-workflow
+  namespace: agent-platform
+roleRef:
+  kind: Role
+  name: argo-events-workflows-agent-platform
+  apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
- Introduced a new RoleBinding to allow the argo-workflow ServiceAccount in the agent-platform namespace to create CodeRuns locally
- This enhances the permissions for the ServiceAccount, facilitating local CodeRun creation and improving workflow management