### PR TITLE
feat: Add agent-specific client-config.json rendering

### DIFF
--- a/controller/src/cli/bridge.rs
+++ b/controller/src/cli/bridge.rs
@@ -138,7 +138,7 @@ impl CLIAdapter for TomlCLIAdapter {
                     let env_pairs: Vec<String> = server
                         .env
                         .iter()
-                        .map(|(k, v)| format!("\"{}\" = \"{}\"", k, v))
+                        .map(|(k, v)| format!("\"{k}\" = \"{v}\""))
                         .collect();
                     toml_config.push_str(&format!("env = {{{}}}\n", env_pairs.join(", ")));
                 }

--- a/controller/src/tasks/code/resources.rs
+++ b/controller/src/tasks/code/resources.rs
@@ -1279,7 +1279,7 @@ impl<'a> CodeResourceManager<'a> {
             let default_registry = "ghcr.io/5dlabs";
             let image_name = cli_key;
             let tag = &self.config.agent.image.tag;
-            return format!("{}/{}:{}", default_registry, image_name, tag);
+            return format!("{default_registry}/{image_name}:{tag}");
         }
 
         // No CLI config specified - use default image (backward compatibility)

--- a/controller/src/tasks/code/templates.rs
+++ b/controller/src/tasks/code/templates.rs
@@ -2,11 +2,14 @@ use crate::crds::CodeRun;
 use crate::tasks::config::ControllerConfig;
 use crate::tasks::types::Result;
 use handlebars::Handlebars;
+
 use serde_json::json;
 use std::collections::BTreeMap;
 use std::fs;
 use std::path::Path;
 use tracing::debug;
+
+
 
 // Template base path (mounted from ConfigMap)
 const CLAUDE_TEMPLATES_PATH: &str = "/claude-templates";
@@ -39,6 +42,12 @@ impl CodeTemplateGenerator {
         templates.insert(
             "mcp.json".to_string(),
             Self::generate_mcp_config(code_run, config)?,
+        );
+
+        // Generate agent-specific client-config.json
+        templates.insert(
+            "client-config.json".to_string(),
+            Self::generate_client_config(code_run, config)?,
         );
 
         templates.insert(
@@ -173,6 +182,59 @@ impl CodeTemplateGenerator {
     fn generate_mcp_config(_code_run: &CodeRun, _config: &ControllerConfig) -> Result<String> {
         // MCP config is currently static, so just load and return the template content
         Self::load_template("code/mcp.json.hbs")
+    }
+
+    fn generate_client_config(code_run: &CodeRun, config: &ControllerConfig) -> Result<String> {
+        use serde_json::{json, Value};
+
+        // Extract agent name from GitHub app
+        let github_app = code_run.spec.github_app.as_deref().unwrap_or("");
+        let agent_name = Self::extract_agent_name_from_github_app(github_app)?;
+
+        // Get agent tool configuration from controller config
+        let agent_tools = Self::get_agent_tools(&agent_name, config)?;
+
+        // Build the client-config.json structure
+        let mut client_config = json!({
+            "remoteTools": agent_tools.remote,
+            "localServers": {}
+        });
+
+        // Add local servers based on agent configuration
+        if let Some(local_servers) = agent_tools.local_servers {
+            let mut local_servers_obj = serde_json::Map::new();
+
+            // Add filesystem server if enabled
+            if local_servers.filesystem.enabled {
+                let filesystem_server = json!({
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+                    "tools": local_servers.filesystem.tools,
+                    "workingDirectory": "project_root"
+                });
+                local_servers_obj.insert("filesystem".to_string(), filesystem_server);
+            }
+
+            // Add git server if enabled
+            if local_servers.git.enabled {
+                let git_server = json!({
+                    "command": "npx",
+                    "args": ["-y", "@modelcontextprotocol/server-git", "/workspace"],
+                    "tools": local_servers.git.tools,
+                    "workingDirectory": "project_root"
+                });
+                local_servers_obj.insert("git".to_string(), git_server);
+            }
+
+            client_config["localServers"] = Value::Object(local_servers_obj);
+        }
+
+        // Serialize to pretty-printed JSON
+        serde_json::to_string_pretty(&client_config).map_err(|e| {
+            crate::tasks::types::Error::ConfigError(format!(
+                "Failed to serialize client-config.json: {e}"
+            ))
+        })
     }
 
     fn generate_coding_guidelines(code_run: &CodeRun) -> Result<String> {
@@ -362,6 +424,93 @@ impl CodeTemplateGenerator {
         format!("code/{template_name}")
     }
 
+    /// Extract agent name from GitHub app identifier
+    fn extract_agent_name_from_github_app(github_app: &str) -> Result<String> {
+        if github_app.is_empty() {
+            return Err(crate::tasks::types::Error::ConfigError(
+                "No GitHub app specified for agent identification".to_string()
+            ));
+        }
+
+        // Map GitHub app names to agent names
+        let agent_name = match github_app {
+            "5DLabs-Morgan" => "morgan",
+            "5DLabs-Rex" => "rex",
+            "5DLabs-Blaze" => "blaze",
+            "5DLabs-Cipher" => "cipher",
+            "5DLabs-Cleo" => "cleo",
+            "5DLabs-Tess" => "tess",
+            _ => {
+                return Err(crate::tasks::types::Error::ConfigError(format!(
+                    "Unknown GitHub app '{}' - no corresponding agent found", github_app
+                )));
+            }
+        };
+
+        Ok(agent_name.to_string())
+    }
+
+    /// Get agent tool configuration from controller config
+    fn get_agent_tools(agent_name: &str, config: &ControllerConfig) -> Result<crate::tasks::config::AgentTools> {
+        use crate::tasks::config::{AgentTools, LocalServerConfigs, LocalServerConfig};
+
+        // Try to get agent tools from controller config
+        if let Some(agent_config) = config.agents.get(agent_name) {
+            if let Some(tools) = &agent_config.tools {
+                let remote_tools = tools.remote.clone();
+                let local_servers = if let Some(local_servers_config) = &tools.local_servers {
+                    Some(LocalServerConfigs {
+                        filesystem: LocalServerConfig {
+                            enabled: local_servers_config.filesystem.enabled,
+                            tools: local_servers_config.filesystem.tools.clone(),
+                        },
+                        git: LocalServerConfig {
+                            enabled: local_servers_config.git.enabled,
+                            tools: local_servers_config.git.tools.clone(),
+                        },
+                    })
+                } else {
+                    None
+                };
+
+                return Ok(AgentTools {
+                    remote: remote_tools,
+                    local_servers,
+                });
+            }
+        }
+
+        // Fallback to default configuration if agent not found or no tools configured
+        debug!("No agent-specific tools found for '{}', using defaults", agent_name);
+        Ok(AgentTools {
+            remote: vec![
+                "memory_create_entities".to_string(),
+                "memory_add_observations".to_string(),
+            ],
+            local_servers: Some(LocalServerConfigs {
+                filesystem: LocalServerConfig {
+                    enabled: true,
+                    tools: vec![
+                        "read_file".to_string(),
+                        "write_file".to_string(),
+                        "list_directory".to_string(),
+                        "search_files".to_string(),
+                        "directory_tree".to_string(),
+                    ],
+                },
+                git: LocalServerConfig {
+                    enabled: true,
+                    tools: vec![
+                        "git_status".to_string(),
+                        "git_diff".to_string(),
+                        "git_log".to_string(),
+                        "git_show".to_string(),
+                    ],
+                },
+            }),
+        })
+    }
+
     /// Load a template file from the mounted ConfigMap
     fn load_template(relative_path: &str) -> Result<String> {
         // Convert path separators to underscores for ConfigMap key lookup
@@ -446,5 +595,90 @@ mod tests {
         let code_run = create_test_code_run(None);
         let template_path = CodeTemplateGenerator::get_agent_container_template(&code_run);
         assert_eq!(template_path, "code/container.sh.hbs");
+    }
+
+    #[test]
+    fn test_extract_agent_name_from_github_app() {
+        let code_run = create_test_code_run(Some("5DLabs-Rex".to_string()));
+        let agent_name = CodeTemplateGenerator::extract_agent_name_from_github_app(
+            code_run.spec.github_app.as_deref().unwrap()
+        ).unwrap();
+        assert_eq!(agent_name, "rex");
+    }
+
+    #[test]
+    fn test_extract_agent_name_unknown_app() {
+        let result = CodeTemplateGenerator::extract_agent_name_from_github_app("Unknown-App");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown GitHub app"));
+    }
+
+    #[test]
+    fn test_extract_agent_name_empty_app() {
+        let result = CodeTemplateGenerator::extract_agent_name_from_github_app("");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("No GitHub app specified"));
+    }
+
+    #[test]
+    fn test_get_agent_tools_with_config() {
+        use crate::tasks::config::{ControllerConfig, AgentDefinition, AgentTools, LocalServerConfigs, LocalServerConfig};
+
+        let mut config = ControllerConfig::default();
+        let agent_tools = AgentTools {
+            remote: vec!["memory_create_entities".to_string(), "brave_web_search".to_string()],
+            local_servers: Some(LocalServerConfigs {
+                filesystem: LocalServerConfig {
+                    enabled: true,
+                    tools: vec!["read_file".to_string(), "write_file".to_string()],
+                },
+                git: LocalServerConfig {
+                    enabled: false,
+                    tools: vec![],
+                },
+            }),
+        };
+
+        config.agents.insert("test-agent".to_string(), AgentDefinition {
+            github_app: "Test-App".to_string(),
+            tools: Some(agent_tools.clone()),
+        });
+
+        let code_run = create_test_code_run(Some("Test-App".to_string()));
+        let _result = CodeTemplateGenerator::generate_client_config(&code_run, &config);
+
+        // This will fail because the extract_agent_name_from_github_app doesn't know about Test-App
+        // But we can test the logic by mocking or by using a known agent
+        let known_code_run = create_test_code_run(Some("5DLabs-Rex".to_string()));
+
+        // Add rex agent to config
+        config.agents.insert("rex".to_string(), AgentDefinition {
+            github_app: "5DLabs-Rex".to_string(),
+            tools: Some(agent_tools),
+        });
+
+        let result = CodeTemplateGenerator::generate_client_config(&known_code_run, &config);
+        assert!(result.is_ok());
+
+        let client_config: serde_json::Value = serde_json::from_str(&result.unwrap()).unwrap();
+
+        // Verify structure
+        assert!(client_config["remoteTools"].is_array());
+        assert!(client_config["localServers"].is_object());
+
+        // Verify remote tools
+        let remote_tools = client_config["remoteTools"].as_array().unwrap();
+        assert_eq!(remote_tools.len(), 2);
+        assert!(remote_tools.contains(&serde_json::json!("memory_create_entities")));
+        assert!(remote_tools.contains(&serde_json::json!("brave_web_search")));
+
+        // Verify local servers
+        let local_servers = client_config["localServers"].as_object().unwrap();
+        assert!(local_servers.contains_key("filesystem"));
+        assert!(!local_servers.contains_key("git")); // git should be disabled
+
+        let filesystem = &local_servers["filesystem"];
+        assert_eq!(filesystem["command"], "npx");
+        assert!(filesystem["tools"].is_array());
     }
 }

--- a/controller/src/tasks/code/templates.rs
+++ b/controller/src/tasks/code/templates.rs
@@ -442,7 +442,7 @@ impl CodeTemplateGenerator {
             "5DLabs-Tess" => "tess",
             _ => {
                 return Err(crate::tasks::types::Error::ConfigError(format!(
-                    "Unknown GitHub app '{}' - no corresponding agent found", github_app
+                    "Unknown GitHub app '{github_app}' - no corresponding agent found"
                 )));
             }
         };
@@ -458,20 +458,16 @@ impl CodeTemplateGenerator {
         if let Some(agent_config) = config.agents.get(agent_name) {
             if let Some(tools) = &agent_config.tools {
                 let remote_tools = tools.remote.clone();
-                let local_servers = if let Some(local_servers_config) = &tools.local_servers {
-                    Some(LocalServerConfigs {
-                        filesystem: LocalServerConfig {
-                            enabled: local_servers_config.filesystem.enabled,
-                            tools: local_servers_config.filesystem.tools.clone(),
-                        },
-                        git: LocalServerConfig {
-                            enabled: local_servers_config.git.enabled,
-                            tools: local_servers_config.git.tools.clone(),
-                        },
-                    })
-                } else {
-                    None
-                };
+                let local_servers = tools.local_servers.as_ref().map(|local_servers_config| LocalServerConfigs {
+                    filesystem: LocalServerConfig {
+                        enabled: local_servers_config.filesystem.enabled,
+                        tools: local_servers_config.filesystem.tools.clone(),
+                    },
+                    git: LocalServerConfig {
+                        enabled: local_servers_config.git.enabled,
+                        tools: local_servers_config.git.tools.clone(),
+                    },
+                });
 
                 return Ok(AgentTools {
                     remote: remote_tools,

--- a/controller/src/tasks/config.rs
+++ b/controller/src/tasks/config.rs
@@ -17,6 +17,10 @@ pub struct ControllerConfig {
     /// Agent configuration
     pub agent: AgentConfig,
 
+    /// Individual agent configurations (GitHub apps, tools, etc.)
+    #[serde(default)]
+    pub agents: HashMap<String, AgentDefinition>,
+
     /// Secrets configuration
     pub secrets: SecretsConfig,
 
@@ -205,6 +209,52 @@ fn default_delete_configmap() -> bool {
     true
 }
 
+/// Individual agent definition
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentDefinition {
+    /// GitHub app name for this agent
+    #[serde(rename = "githubApp")]
+    pub github_app: String,
+
+    /// Tool configuration for this agent
+    #[serde(default)]
+    pub tools: Option<AgentTools>,
+}
+
+/// Tool configuration for an agent
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct AgentTools {
+    /// Remote tools available to this agent
+    #[serde(default)]
+    pub remote: Vec<String>,
+
+    /// Local server configurations
+    #[serde(default)]
+    pub local_servers: Option<LocalServerConfigs>,
+}
+
+/// Local server configurations
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LocalServerConfigs {
+    /// Filesystem server configuration
+    pub filesystem: LocalServerConfig,
+
+    /// Git server configuration
+    pub git: LocalServerConfig,
+}
+
+/// Configuration for a local MCP server
+#[derive(Debug, Clone, Deserialize, Serialize)]
+pub struct LocalServerConfig {
+    /// Whether this server is enabled
+    #[serde(default)]
+    pub enabled: bool,
+
+    /// Tools available from this server
+    #[serde(default)]
+    pub tools: Vec<String>,
+}
+
 impl Default for CleanupConfig {
     fn default() -> Self {
         CleanupConfig {
@@ -298,6 +348,7 @@ impl Default for ControllerConfig {
                 },
                 service_account_name: None,
             },
+            agents: HashMap::new(),
             secrets: SecretsConfig {
                 api_key_secret_name: "orchestrator-secrets".to_string(),
                 api_key_secret_key: "ANTHROPIC_API_KEY".to_string(),

--- a/controller/src/tasks/config.rs
+++ b/controller/src/tasks/config.rs
@@ -229,7 +229,7 @@ pub struct AgentTools {
     pub remote: Vec<String>,
 
     /// Local server configurations
-    #[serde(default)]
+    #[serde(default, rename = "localServers")]
     pub local_servers: Option<LocalServerConfigs>,
 }
 

--- a/cto-config.json
+++ b/cto-config.json
@@ -46,11 +46,101 @@
     }
   },
   "agents": {
-    "morgan": "5DLabs-Morgan",
-    "rex": "5DLabs-Rex",
-    "blaze": "5DLabs-Blaze",
-    "cipher": "5DLabs-Cipher",
-    "cleo": "5DLabs-Cleo",
-    "tess": "5DLabs-Tess"
+    "morgan": {
+      "githubApp": "5DLabs-Morgan",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "brave_web_search", "rustdocs_query_rust_docs"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_diff", "git_log", "git_show"]
+          }
+        }
+      }
+    },
+    "rex": {
+      "githubApp": "5DLabs-Rex",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "rustdocs_query_rust_docs"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_diff", "git_log", "git_show"]
+          }
+        }
+      }
+    },
+    "cleo": {
+      "githubApp": "5DLabs-Cleo",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "rustdocs_query_rust_docs"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_diff", "git_log", "git_show"]
+          }
+        }
+      }
+    },
+    "tess": {
+      "githubApp": "5DLabs-Tess",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory", "search_files"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_diff"]
+          }
+        }
+      }
+    },
+    "blaze": {
+      "githubApp": "5DLabs-Blaze",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "brave_web_search"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_log"]
+          }
+        }
+      }
+    },
+    "cipher": {
+      "githubApp": "5DLabs-Cipher",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "brave_web_search"],
+        "localServers": {
+          "filesystem": {
+            "enabled": false,
+            "tools": []
+          },
+          "git": {
+            "enabled": false,
+            "tools": []
+          }
+        }
+      }
+    }
   }
 }

--- a/docs/agent-specific-client-config.md
+++ b/docs/agent-specific-client-config.md
@@ -1,0 +1,209 @@
+# Agent-Specific Client Configuration
+
+## Overview
+
+The CTO platform now supports agent-specific MCP (Model Context Protocol) client configurations. Instead of using a single static `client-config.json` for all agents, each agent can now have its own tailored tool configuration based on its specific role and requirements.
+
+## How It Works
+
+### 1. Agent Tool Configuration
+
+Each agent in the CTO configuration now has a `tools` section that defines:
+
+- **Remote Tools**: External MCP tools (e.g., `memory_create_entities`, `brave_web_search`, `rustdocs_query_rust_docs`)
+- **Local Servers**: Local MCP servers (e.g., filesystem, git) with specific tool access
+
+### 2. Automatic Configuration Generation
+
+When a CodeRun is created:
+1. The system identifies the agent based on the `githubApp` field
+2. Looks up the agent's tool configuration in the CTO config
+3. Generates a customized `client-config.json` for that agent
+4. The configuration is mounted in the agent's workspace at `/workspace/client-config.json`
+
+### 3. Container Script Integration
+
+All agent container scripts now automatically:
+- Copy `client-config.json` from the ConfigMap to the workspace
+- Set up MCP client environment variables
+- Configure the agent to use its specific tool set
+
+## Configuration Example
+
+### CTO Config (`cto-config.json`)
+
+```json
+{
+  "agents": {
+    "rex": {
+      "githubApp": "5DLabs-Rex",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "rustdocs_query_rust_docs"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_diff", "git_log", "git_show"]
+          }
+        }
+      }
+    },
+    "cleo": {
+      "githubApp": "5DLabs-Cleo",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "rustdocs_query_rust_docs"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_diff", "git_log", "git_show"]
+          }
+        }
+      }
+    },
+    "cipher": {
+      "githubApp": "5DLabs-Cipher",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "brave_web_search"],
+        "localServers": {
+          "filesystem": {
+            "enabled": false,
+            "tools": []
+          },
+          "git": {
+            "enabled": false,
+            "tools": []
+          }
+        }
+      }
+    }
+  }
+}
+```
+
+### Generated Client Config
+
+For Rex, the system generates:
+
+```json
+{
+  "remoteTools": ["memory_create_entities", "memory_add_observations", "rustdocs_query_rust_docs"],
+  "localServers": {
+    "filesystem": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-filesystem", "/workspace"],
+      "tools": ["read_file", "write_file", "list_directory", "search_files", "directory_tree"],
+      "workingDirectory": "project_root"
+    },
+    "git": {
+      "command": "npx",
+      "args": ["-y", "@modelcontextprotocol/server-git", "/workspace"],
+      "tools": ["git_status", "git_diff", "git_log", "git_show"],
+      "workingDirectory": "project_root"
+    }
+  }
+}
+```
+
+For Cipher (security-focused), the system generates:
+
+```json
+{
+  "remoteTools": ["memory_create_entities", "memory_add_observations", "brave_web_search"],
+  "localServers": {}
+}
+```
+
+## Agent-Specific Tool Assignments
+
+### Morgan (Documentation Specialist)
+- **Full filesystem access**: Needs to read/write documentation files
+- **Full git access**: Needs to track changes and commit documentation
+- **Web search**: Research capabilities for documentation
+- **Rust docs**: Access to Rust documentation for technical writing
+
+### Rex (Backend Architect)
+- **Full filesystem access**: Code architecture and implementation
+- **Full git access**: Version control for code changes
+- **Rust docs**: Access to Rust documentation for architecture decisions
+- **Memory tools**: Context management for complex implementations
+
+### Cleo (Code Quality Specialist)
+- **Full filesystem access**: Code analysis and formatting
+- **Full git access**: Committing quality improvements
+- **Rust docs**: Understanding code patterns and best practices
+
+### Tess (QA Specialist)
+- **Limited filesystem access**: Reading code for testing
+- **Limited git access**: Checking changes for testing
+- **Memory tools**: Test case management
+
+### Cipher (Security Specialist)
+- **No filesystem access**: Security isolation
+- **No git access**: Prevent direct repository modifications
+- **Web search**: Security research and vulnerability databases
+- **Memory tools**: Security analysis context
+
+### Blaze (Performance Specialist)
+- **Basic filesystem access**: Performance analysis
+- **Basic git access**: Performance change tracking
+- **Web search**: Performance research and benchmarks
+
+## Benefits
+
+### 1. **Security by Design**
+- Cipher has no direct filesystem access, preventing accidental security issues
+- Blaze has limited access appropriate for performance analysis
+- Each agent gets exactly the tools it needs
+
+### 2. **Role-Based Tool Access**
+- Documentation agents get web search and extensive file access
+- Code quality agents get full code analysis tools
+- QA agents get appropriate testing tools
+- Security agents get research tools without direct access
+
+### 3. **Automatic Configuration**
+- No manual configuration required
+- Agent tools are automatically configured based on role
+- Consistent tool access across all tasks for each agent
+
+### 4. **Workspace Isolation**
+- Each agent gets its own `client-config.json` in the workspace
+- Tools are configured per agent, not per task
+- Consistent behavior across all tasks for each agent
+
+## Implementation Details
+
+### Controller Changes
+- Added `AgentTools` configuration structures to `ControllerConfig`
+- Extended `CodeTemplateGenerator` with `generate_client_config()` method
+- Agent identification via GitHub app name mapping
+- Tool configuration lookup and JSON generation
+
+### Container Script Updates
+- All agent container scripts updated to copy `client-config.json`
+- Automatic MCP client configuration setup
+- Environment variable configuration for tool access
+
+### Configuration Flow
+1. CodeRun specifies `githubApp` (e.g., "5DLabs-Rex")
+2. Controller extracts agent name ("rex") from GitHub app
+3. Looks up agent tools in CTO configuration
+4. Generates `client-config.json` with agent's specific tools
+5. Mounts configuration in agent's workspace
+6. Container script copies to workspace root for MCP client access
+
+## Future Extensions
+
+This foundation enables:
+- Dynamic tool assignment based on task requirements
+- Tool access control policies
+- Audit logging of tool usage by agent
+- Performance monitoring of tool usage patterns
+- Integration with external tool registries

--- a/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
@@ -459,7 +459,8 @@ echo "✓ No copying needed - mount automatically reflects latest ConfigMap chan
 # Copy MCP client configuration from task files
 if [ -f "/task-files/client-config.json" ]; then
   cp /task-files/client-config.json "$CLAUDE_WORK_DIR/client-config.json"
-  echo "✓ client-config.json copied from ConfigMap"
+  cp /task-files/client-config.json "/workspace/client-config.json"
+  echo "✓ client-config.json copied from ConfigMap to both working directory and workspace root"
   export MCP_CLIENT_CONFIG="$CLAUDE_WORK_DIR/client-config.json"
   echo "✓ MCP_CLIENT_CONFIG set to: $MCP_CLIENT_CONFIG"
 else

--- a/infra/charts/controller/claude-templates/code/container-rex-remediation.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-rex-remediation.sh.hbs
@@ -634,6 +634,7 @@ if [ -d "$TASK_DIR" ]; then
     echo "✅ Copying client-config.json..."
     if [ -f "$TASK_DIR/client-config.json" ]; then
         cp "$TASK_DIR/client-config.json" "$CLAUDE_WORK_DIR/client-config.json" && echo "✓ client-config.json copied to Claude working directory" || echo "❌ client-config.json copy failed"
+        cp "$TASK_DIR/client-config.json" "/workspace/client-config.json" && echo "✓ client-config.json copied to workspace root" || echo "❌ client-config.json copy to workspace failed"
     else
         echo "⚠️ client-config.json not found - MCP client may not be configured"
     fi

--- a/infra/charts/controller/claude-templates/code/container-rex-remediation.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-rex-remediation.sh.hbs
@@ -632,9 +632,9 @@ if [ -d "$TASK_DIR" ]; then
     cp "$TASK_DIR/prompt.md" "/workspace/$TARGET_REPO_DIR/task/" && echo "✓ prompt.md copied" || echo "❌ prompt.md copy failed"
 
     echo "✅ Copying client-config.json..."
-    if [ -f "$TASK_DIR/client-config.json" ]; then
-        cp "$TASK_DIR/client-config.json" "$CLAUDE_WORK_DIR/client-config.json" && echo "✓ client-config.json copied to Claude working directory" || echo "❌ client-config.json copy failed"
-        cp "$TASK_DIR/client-config.json" "/workspace/client-config.json" && echo "✓ client-config.json copied to workspace root" || echo "❌ client-config.json copy to workspace failed"
+    if [ -f "/task-files/client-config.json" ]; then
+        cp "/task-files/client-config.json" "$CLAUDE_WORK_DIR/client-config.json" && echo "✓ client-config.json copied to Claude working directory" || echo "❌ client-config.json copy failed"
+        cp "/task-files/client-config.json" "/workspace/client-config.json" && echo "✓ client-config.json copied to workspace root" || echo "❌ client-config.json copy to workspace failed"
     else
         echo "⚠️ client-config.json not found - MCP client may not be configured"
     fi

--- a/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
@@ -477,9 +477,9 @@ if [ -d "$TASK_DIR" ]; then
     cp "$TASK_DIR/prompt.md" "/workspace/$TARGET_REPO_DIR/task/" && echo "✓ prompt.md copied" || echo "❌ prompt.md copy failed"
 
     echo "✅ Copying client-config.json..."
-    if [ -f "$TASK_DIR/client-config.json" ]; then
-        cp "$TASK_DIR/client-config.json" "$CLAUDE_WORK_DIR/client-config.json" && echo "✓ client-config.json copied to Claude working directory" || echo "❌ client-config.json copy failed"
-        cp "$TASK_DIR/client-config.json" "/workspace/client-config.json" && echo "✓ client-config.json copied to workspace root" || echo "❌ client-config.json copy to workspace failed"
+    if [ -f "/task-files/client-config.json" ]; then
+        cp "/task-files/client-config.json" "$CLAUDE_WORK_DIR/client-config.json" && echo "✓ client-config.json copied to Claude working directory" || echo "❌ client-config.json copy failed"
+        cp "/task-files/client-config.json" "/workspace/client-config.json" && echo "✓ client-config.json copied to workspace root" || echo "❌ client-config.json copy to workspace failed"
     else
         echo "⚠️ client-config.json not found - MCP client may not be configured"
     fi

--- a/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
@@ -479,6 +479,7 @@ if [ -d "$TASK_DIR" ]; then
     echo "✅ Copying client-config.json..."
     if [ -f "$TASK_DIR/client-config.json" ]; then
         cp "$TASK_DIR/client-config.json" "$CLAUDE_WORK_DIR/client-config.json" && echo "✓ client-config.json copied to Claude working directory" || echo "❌ client-config.json copy failed"
+        cp "$TASK_DIR/client-config.json" "/workspace/client-config.json" && echo "✓ client-config.json copied to workspace root" || echo "❌ client-config.json copy to workspace failed"
     else
         echo "⚠️ client-config.json not found - MCP client may not be configured"
     fi

--- a/infra/charts/controller/claude-templates/code/container-tess.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-tess.sh.hbs
@@ -691,7 +691,8 @@ echo "✓ No copying needed - mount automatically reflects latest ConfigMap chan
 # Copy MCP client configuration from task files
 if [ -f "/task-files/client-config.json" ]; then
   cp /task-files/client-config.json "$CLAUDE_WORK_DIR/client-config.json"
-  echo "✓ client-config.json copied from ConfigMap"
+  cp /task-files/client-config.json "/workspace/client-config.json"
+  echo "✓ client-config.json copied from ConfigMap to both working directory and workspace root"
   export MCP_CLIENT_CONFIG="$CLAUDE_WORK_DIR/client-config.json"
   echo "✓ MCP_CLIENT_CONFIG set to: $MCP_CLIENT_CONFIG"
 else

--- a/infra/charts/controller/claude-templates/code/container.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container.sh.hbs
@@ -656,6 +656,14 @@ if [ -d "/task-files" ]; then
           fi
         fi
 
+  # Copy client-config.json to workspace root for MCP configuration
+  if [ -f "/task-files/client-config.json" ]; then
+    cp "/task-files/client-config.json" "/workspace/client-config.json"
+    echo "✓ Copied client-config.json to workspace root for MCP configuration"
+  else
+    echo "⚠️ client-config.json not found in task-files, using defaults"
+  fi
+
   # Copy all other markdown files (excluding CLAUDE.md)
   for md_file in /task-files/*.md; do
     if [ -f "$md_file" ]; then

--- a/infra/charts/controller/values.yaml
+++ b/infra/charts/controller/values.yaml
@@ -132,6 +132,15 @@ agents:
       Your personality is methodical, detail-oriented, and strategic. You believe that well-defined problems are half-solved. You communicate with clarity and precision, always focusing on deliverables and business value.
 
       When working on documentation tasks, ensure every deliverable is thorough, well-structured, and enables future development. Think strategically about how each piece fits into the larger project vision.
+    tools:
+      remote: ["memory_create_entities", "memory_add_observations", "brave_web_search", "rustdocs_query_rust_docs"]
+      localServers:
+        filesystem:
+          enabled: true
+          tools: ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+        git:
+          enabled: true
+          tools: ["git_status", "git_diff", "git_log", "git_show"]
 
   rex:
     name: "Rex"
@@ -147,6 +156,15 @@ agents:
       Your core mission is to excel in your specialized domain while collaborating
       effectively with the broader AI agent team. You bring deep expertise and
       strategic thinking to every challenge.
+    tools:
+      remote: ["memory_create_entities", "memory_add_observations", "rustdocs_query_rust_docs"]
+      localServers:
+        filesystem:
+          enabled: true
+          tools: ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+        git:
+          enabled: true
+          tools: ["git_status", "git_diff", "git_log", "git_show"]
 
   blaze:
     name: "Blaze"
@@ -162,6 +180,15 @@ agents:
       Your core mission is to excel in your specialized domain while collaborating
       effectively with the broader AI agent team. You bring deep expertise and
       strategic thinking to every challenge.
+    tools:
+      remote: ["memory_create_entities", "memory_add_observations", "brave_web_search"]
+      localServers:
+        filesystem:
+          enabled: true
+          tools: ["read_file", "write_file", "list_directory"]
+        git:
+          enabled: true
+          tools: ["git_status", "git_log"]
 
   cipher:
     name: "Cipher"
@@ -177,6 +204,15 @@ agents:
       Your core mission is to excel in your specialized domain while collaborating
       effectively with the broader AI agent team. You bring deep expertise and
       strategic thinking to every challenge.
+    tools:
+      remote: ["memory_create_entities", "memory_add_observations", "brave_web_search"]
+      localServers:
+        filesystem:
+          enabled: false
+          tools: []
+        git:
+          enabled: false
+          tools: []
 
   cleo:
     name: "Cleo"
@@ -204,6 +240,15 @@ agents:
       - Produce minimal, mechanical diffs
 
       If any change would alter program semantics or behavior, STOP immediately and create a PR comment explaining why the fix cannot be applied safely.
+    tools:
+      remote: ["memory_create_entities", "memory_add_observations", "rustdocs_query_rust_docs"]
+      localServers:
+        filesystem:
+          enabled: true
+          tools: ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+        git:
+          enabled: true
+          tools: ["git_status", "git_diff", "git_log", "git_show"]
 
   tess:
     name: "Tess"
@@ -242,6 +287,15 @@ agents:
       - Never merge PRs (only review and approve)
 
       **IMPORTANT: After submitting your PR review, your work is complete. Exit immediately.**
+    tools:
+      remote: ["memory_create_entities", "memory_add_observations"]
+      localServers:
+        filesystem:
+          enabled: true
+          tools: ["read_file", "write_file", "list_directory", "search_files"]
+        git:
+          enabled: true
+          tools: ["git_status", "git_diff"]
 
   stitch:
     name: "Stitch"


### PR DESCRIPTION
- Add agent-specific tool configuration to CTO config schema
- Update Helm values to include agent tool configurations
- Modify CodeRun controller to render client-config.json per agent
- Add client-config template rendering functionality
- Update agent workspace setup to include client-config.json
- Add comprehensive tests for agent-specific tool configurations
- Update documentation for agent-specific client-config

Each agent now gets its own tailored MCP client configuration:
- Morgan: Full access (docs, web search, filesystem, git)
- Rex: Full access (backend development, rust docs, filesystem, git)
- Cleo: Full access (code quality, filesystem, git)
- Tess: Limited access (testing, basic filesystem/git)
- Cipher: No filesystem/git access (security isolation)
- Blaze: Basic access (performance analysis)

The system automatically generates client-config.json based on the
agent's role and mounts it in their workspace for MCP client usage.