### PR TITLE
feat: Add agent-docs service to toolman configuration

### DIFF
--- a/infra/gitops/applications/toolman.yaml
+++ b/infra/gitops/applications/toolman.yaml
@@ -103,6 +103,14 @@ spec:
               args: ["-y", "@upstash/context7-mcp"]
               workingDirectory: "/tmp"
 
+            agent-docs:
+              name: "Agent Docs"
+              description: "Agent documentation and knowledge base server"
+              transport: "docker"
+              command: "docker"
+              args: ["run", "-i", "--rm", "ghcr.io/5dlabs/agent-docs/server"]
+              workingDirectory: "/tmp"
+
         # Local tools configuration for client-side operations
         localTools:
           servers:


### PR DESCRIPTION
- Introduced a new service definition for "Agent Docs" in the toolman.yaml file.
- This service serves as a documentation and knowledge base server, utilizing Docker for deployment.
- The addition enhances the toolman application by providing a dedicated resource for agent-related documentation.