### PR TITLE
fix: Update agent-docs service configuration in toolman.yaml

### DIFF
--- a/infra/gitops/applications/toolman.yaml
+++ b/infra/gitops/applications/toolman.yaml
@@ -106,9 +106,8 @@ spec:
             agent-docs:
               name: "Agent Docs"
               description: "Agent documentation and knowledge base server"
-              transport: "docker"
-              command: "docker"
-              args: ["run", "-i", "--rm", "ghcr.io/5dlabs/agent-docs/server"]
+              transport: "http"
+              url: "http://doc-server-agent-docs-server.mcp.svc.cluster.local:80/mcp"
               workingDirectory: "/tmp"
 
         # Local tools configuration for client-side operations


### PR DESCRIPTION
- Changed the transport method for the "Agent Docs" service from Docker to HTTP.
- Updated the command to use a URL for accessing the documentation server, enhancing deployment flexibility.