### PR TITLE
feat: implement multi-CLI functionality for play workflow

### DIFF
--- a/cto-config-example.json
+++ b/cto-config-example.json
@@ -1,0 +1,159 @@
+{
+  "version": "1.0",
+  "defaults": {
+    "docs": {
+      "model": "claude-opus-4-1-20250805",
+      "githubApp": "5DLabs-Morgan",
+      "includeCodebase": false,
+      "sourceBranch": "main"
+    },
+    "code": {
+      "model": "claude-opus-4-1-20250805",
+      "githubApp": "5DLabs-Rex",
+      "continueSession": false,
+      "workingDirectory": ".",
+      "overwriteMemory": false,
+      "repository": "5dlabs/cto",
+      "docsRepository": "5dlabs/cto",
+      "docsProjectDirectory": "docs",
+      "service": "cto"
+    },
+    "intake": {
+      "githubApp": "5DLabs-Morgan",
+      "primary": {
+        "model": "opus",
+        "provider": "claude-code"
+      },
+      "research": {
+        "model": "opus",
+        "provider": "claude-code"
+      },
+      "fallback": {
+        "model": "gpt-5",
+        "provider": "openai"
+      }
+    },
+    "play": {
+      "model": "claude-sonnet-4-20250514",
+      "cli": "claude",
+      "implementationAgent": "5DLabs-Rex",
+      "qualityAgent": "5DLabs-Cleo",
+      "testingAgent": "5DLabs-Tess",
+      "repository": "5dlabs/cto-play-test",
+      "service": "cto-play-test",
+      "docsRepository": "5dlabs/cto-play-test",
+      "docsProjectDirectory": "docs",
+      "workingDirectory": "/Users/jonathonfritz/cto-play-test"
+    }
+  },
+  "agents": {
+    "morgan": {
+      "githubApp": "5DLabs-Morgan",
+      "cli": "claude",
+ "model": "claude-sonnet-4-20250514",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "brave_web_search", "rustdocs_query_rust_docs"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_diff", "git_log", "git_show"]
+          }
+        }
+      }
+    },
+    "rex": {
+      "githubApp": "5DLabs-Rex",
+      "cli": "claude",
+      "model": "claude-sonnet-4-20250514",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "rustdocs_query_rust_docs"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_diff", "git_log", "git_show"]
+          }
+        }
+      }
+    },
+    "cleo": {
+      "githubApp": "5DLabs-Cleo",
+      "cli": "claude",
+      "model": "claude-sonnet-4-20250514",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "rustdocs_query_rust_docs"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory", "search_files", "directory_tree"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_diff", "git_log", "git_show"]
+          }
+        }
+      }
+    },
+    "tess": {
+      "githubApp": "5DLabs-Tess",
+      "cli": "claude",
+      "model": "claude-sonnet-4-20250514",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory", "search_files"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_diff"]
+          }
+        }
+      }
+    },
+    "blaze": {
+      "githubApp": "5DLabs-Blaze",
+      "cli": "claude",
+      "model": "claude-sonnet-4-20250514",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "brave_web_search"],
+        "localServers": {
+          "filesystem": {
+            "enabled": true,
+            "tools": ["read_file", "write_file", "list_directory"]
+          },
+          "git": {
+            "enabled": true,
+            "tools": ["git_status", "git_log"]
+          }
+        }
+      }
+    },
+    "cipher": {
+      "githubApp": "5DLabs-Cipher",
+      "cli": "claude",
+      "model": "claude-sonnet-4-20250514",
+      "tools": {
+        "remote": ["memory_create_entities", "memory_add_observations", "brave_web_search"],
+        "localServers": {
+          "filesystem": {
+            "enabled": false,
+            "tools": []
+          },
+          "git": {
+            "enabled": false,
+            "tools": []
+          }
+        }
+      }
+    }
+  }
+}

--- a/mcp/src/main.rs
+++ b/mcp/src/main.rs
@@ -16,10 +16,44 @@ mod tools;
 static CTO_CONFIG: OnceLock<CtoConfig> = OnceLock::new();
 
 #[derive(Debug, Deserialize, Clone)]
+struct AgentConfig {
+    #[serde(rename = "githubApp")]
+    github_app: String,
+    cli: String,
+    model: String,
+    #[allow(dead_code)]
+    tools: AgentTools,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct AgentTools {
+    #[allow(dead_code)]
+    remote: Vec<String>,
+    #[allow(dead_code)]
+    local_servers: LocalServerConfig,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct LocalServerConfig {
+    #[allow(dead_code)]
+    filesystem: ServerConfig,
+    #[allow(dead_code)]
+    git: ServerConfig,
+}
+
+#[derive(Debug, Deserialize, Clone)]
+struct ServerConfig {
+    #[allow(dead_code)]
+    enabled: bool,
+    #[allow(dead_code)]
+    tools: Vec<String>,
+}
+
+#[derive(Debug, Deserialize, Clone)]
 struct CtoConfig {
     version: String,
     defaults: WorkflowDefaults,
-    agents: HashMap<String, String>,
+    agents: HashMap<String, AgentConfig>,
 }
 
 #[derive(Debug, Deserialize, Clone)]
@@ -98,9 +132,10 @@ impl Default for IntakeDefaults {
     }
 }
 
-#[derive(Debug, Deserialize, Clone)]
+#[derive(Debug, Deserialize, Clone, Default)]
 struct PlayDefaults {
     model: String,
+    cli: String,
     #[serde(rename = "implementationAgent")]
     implementation_agent: String,
     #[serde(rename = "qualityAgent")]
@@ -115,21 +150,7 @@ struct PlayDefaults {
     docs_project_directory: Option<String>,
 }
 
-impl Default for PlayDefaults {
-    fn default() -> Self {
-        // No defaults - require explicit configuration
-        PlayDefaults {
-            model: String::new(),
-            implementation_agent: String::new(),
-            quality_agent: String::new(),
-            testing_agent: String::new(),
-            repository: None,
-            service: None,
-            docs_repository: None,
-            docs_project_directory: None,
-        }
-    }
-}
+
 
 /// Load configuration from cto-config.json file
 /// Looks in current directory, workspace root, or WORKSPACE_FOLDER_PATHS for cto-config.json
@@ -571,7 +592,7 @@ fn handle_docs_workflow(arguments: &HashMap<String, Value>) -> Result<Value> {
                 available_agents
             ));
         }
-        config.agents[agent].clone()
+        config.agents[agent].github_app.clone()
     } else {
         // Use default from config
         config.defaults.docs.github_app.clone()
@@ -749,7 +770,7 @@ fn handle_code_workflow(arguments: &HashMap<String, Value>) -> Result<Value> {
                 available_agents
             ));
         }
-        config.agents[agent].clone()
+        config.agents[agent].github_app.clone()
     } else {
         // Use default from config
         config.defaults.code.github_app.clone()
@@ -965,49 +986,20 @@ fn handle_play_workflow(arguments: &HashMap<String, Value>) -> Result<Value> {
         .or(config.defaults.play.docs_project_directory.as_deref())
         .ok_or(anyhow!("Missing required parameter: docs_project_directory. Please provide it or set defaults.play.docsProjectDirectory in config"))?;
 
-    // Handle implementation agent - use provided value or config default
-    let implementation_agent_input = arguments
-        .get("implementation_agent")
+    // Handle CLI - use provided value or config default (needed for agent resolution)
+    let cli = arguments
+        .get("cli")
         .and_then(|v| v.as_str())
         .map(String::from)
-        .unwrap_or_else(|| config.defaults.play.implementation_agent.clone());
-    
-    // Resolve agent name if it's a short alias
-    let implementation_agent = if config.agents.contains_key(&implementation_agent_input) {
-        config.agents[&implementation_agent_input].clone()
-    } else {
-        implementation_agent_input
-    };
+        .unwrap_or_else(|| {
+            eprintln!(
+                "🐛 DEBUG: Using play default CLI: {}",
+                config.defaults.play.cli
+            );
+            config.defaults.play.cli.clone()
+        });
 
-    // Handle quality agent - use provided value or config default
-    let quality_agent_input = arguments
-        .get("quality_agent")
-        .and_then(|v| v.as_str())
-        .map(String::from)
-        .unwrap_or_else(|| config.defaults.play.quality_agent.clone());
-    
-    // Resolve agent name if it's a short alias
-    let quality_agent = if config.agents.contains_key(&quality_agent_input) {
-        config.agents[&quality_agent_input].clone()
-    } else {
-        quality_agent_input
-    };
-
-    // Handle testing agent - use provided value or config default
-    let testing_agent_input = arguments
-        .get("testing_agent")
-        .and_then(|v| v.as_str())
-        .map(String::from)
-        .unwrap_or_else(|| config.defaults.play.testing_agent.clone());
-    
-    // Resolve agent name if it's a short alias
-    let testing_agent = if config.agents.contains_key(&testing_agent_input) {
-        config.agents[&testing_agent_input].clone()
-    } else {
-        testing_agent_input
-    };
-
-    // Handle model - use provided value or config default
+    // Handle model - use provided value or config default (needed for agent resolution)
     let model = arguments
         .get("model")
         .and_then(|v| v.as_str())
@@ -1020,6 +1012,60 @@ fn handle_play_workflow(arguments: &HashMap<String, Value>) -> Result<Value> {
             config.defaults.play.model.clone()
         });
 
+    // Handle implementation agent - use provided value or config default
+    let implementation_agent_input = arguments
+        .get("implementation_agent")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| config.defaults.play.implementation_agent.clone());
+
+    // Resolve agent name and extract CLI/model if it's a short alias
+    let (implementation_agent, implementation_cli, implementation_model) = if let Some(agent_config) = config.agents.get(&implementation_agent_input) {
+        // Use the structured agent configuration
+        let agent_cli = if agent_config.cli.is_empty() { cli.clone() } else { agent_config.cli.clone() };
+        let agent_model = if agent_config.model.is_empty() { model.clone() } else { agent_config.model.clone() };
+        (agent_config.github_app.clone(), agent_cli, agent_model)
+    } else {
+        // Not a configured agent, use provided name with defaults
+        (implementation_agent_input, cli.clone(), model.clone())
+    };
+
+    // Handle quality agent - use provided value or config default
+    let quality_agent_input = arguments
+        .get("quality_agent")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| config.defaults.play.quality_agent.clone());
+
+    // Resolve agent name and extract CLI/model if it's a short alias
+    let (quality_agent, quality_cli, quality_model) = if let Some(agent_config) = config.agents.get(&quality_agent_input) {
+        // Use the structured agent configuration
+        let agent_cli = if agent_config.cli.is_empty() { cli.clone() } else { agent_config.cli.clone() };
+        let agent_model = if agent_config.model.is_empty() { model.clone() } else { agent_config.model.clone() };
+        (agent_config.github_app.clone(), agent_cli, agent_model)
+    } else {
+        // Not a configured agent, use provided name with defaults
+        (quality_agent_input, cli.clone(), model.clone())
+    };
+
+    // Handle testing agent - use provided value or config default
+    let testing_agent_input = arguments
+        .get("testing_agent")
+        .and_then(|v| v.as_str())
+        .map(String::from)
+        .unwrap_or_else(|| config.defaults.play.testing_agent.clone());
+
+    // Resolve agent name and extract CLI/model if it's a short alias
+    let (testing_agent, testing_cli, testing_model) = if let Some(agent_config) = config.agents.get(&testing_agent_input) {
+        // Use the structured agent configuration
+        let agent_cli = if agent_config.cli.is_empty() { cli.clone() } else { agent_config.cli.clone() };
+        let agent_model = if agent_config.model.is_empty() { model.clone() } else { agent_config.model.clone() };
+        (agent_config.github_app.clone(), agent_cli, agent_model)
+    } else {
+        // Not a configured agent, use provided name with defaults
+        (testing_agent_input, cli.clone(), model.clone())
+    };
+
     // Validate model name (support both Claude API and CLAUDE code formats)
     if !model.starts_with("claude-") && !["opus", "sonnet", "haiku"].contains(&model.as_str()) {
         return Err(anyhow!(
@@ -1031,9 +1077,9 @@ fn handle_play_workflow(arguments: &HashMap<String, Value>) -> Result<Value> {
     eprintln!("🐛 DEBUG: Play workflow submitting with task_id: {task_id}");
     eprintln!("🐛 DEBUG: Play workflow repository: {repository}");
     eprintln!("🐛 DEBUG: Play workflow service: {service}");
-    eprintln!("🐛 DEBUG: Implementation agent: {implementation_agent}");
-    eprintln!("🐛 DEBUG: Quality agent: {quality_agent}");
-    eprintln!("🐛 DEBUG: Testing agent: {testing_agent}");
+    eprintln!("🐛 DEBUG: Implementation agent: {implementation_agent} (CLI: {implementation_cli}, Model: {implementation_model})");
+    eprintln!("🐛 DEBUG: Quality agent: {quality_agent} (CLI: {quality_cli}, Model: {quality_model})");
+    eprintln!("🐛 DEBUG: Testing agent: {testing_agent} (CLI: {testing_cli}, Model: {testing_model})");
 
     // Check for requirements.yaml file
     // Try to determine workspace directory, but don't fail if we can't
@@ -1078,8 +1124,14 @@ fn handle_play_workflow(arguments: &HashMap<String, Value>) -> Result<Value> {
         format!("docs-repository={docs_repository}"),
         format!("docs-project-directory={docs_project_directory}"),
         format!("implementation-agent={implementation_agent}"),
+        format!("implementation-cli={implementation_cli}"),
+        format!("implementation-model={implementation_model}"),
         format!("quality-agent={quality_agent}"),
+        format!("quality-cli={quality_cli}"),
+        format!("quality-model={quality_model}"),
         format!("testing-agent={testing_agent}"),
+        format!("testing-cli={testing_cli}"),
+        format!("testing-model={testing_model}"),
         format!("model={model}"),
     ];
 

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -18,7 +18,7 @@ pub fn get_tool_schemas() -> Value {
 }
 
 /// Get tool schemas with config-based agent descriptions
-pub fn get_tool_schemas_with_config(agents: &HashMap<String, String>) -> Value {
+pub fn get_tool_schemas_with_config(agents: &HashMap<String, crate::AgentConfig>) -> Value {
     json!({
         "tools": [
             get_docs_schema(),
@@ -62,7 +62,7 @@ fn get_docs_schema() -> Value {
     })
 }
 
-fn get_code_schema(agents: &HashMap<String, String>) -> Value {
+fn get_code_schema(agents: &HashMap<String, crate::AgentConfig>) -> Value {
     json!({
         "name": "code",
         "description": "Submit a Task Master task for implementation using Claude with persistent workspace",
@@ -151,7 +151,7 @@ fn get_code_schema(agents: &HashMap<String, String>) -> Value {
     })
 }
 
-fn get_play_schema(agents: &HashMap<String, String>) -> Value {
+fn get_play_schema(agents: &HashMap<String, crate::AgentConfig>) -> Value {
     json!({
         "name": "play",
         "description": "Submit a Play workflow for multi-agent orchestration (Rex/Blaze → Cleo → Tess) with event-driven coordination",
@@ -210,6 +210,10 @@ fn get_play_schema(agents: &HashMap<String, String>) -> Value {
                 "model": {
                     "type": "string",
                     "description": "Claude model to use for all agents (optional, defaults to configuration)"
+                },
+                "cli": {
+                    "type": "string",
+                    "description": "CLI tool to use for all agents (optional, defaults to configuration)"
                 }
             },
             "required": ["task_id"]


### PR DESCRIPTION
- Add CLI configuration to PlayDefaults struct
- Update agent resolution to extract CLI/model from agent config
- Support CLI overrides via MCP tool parameters
- Pass agent-specific CLI/model to Argo workflow
- Update CTO config example with CLI defaults
- Fix compilation warnings and type signatures