### PR TITLE
feat: Add ANTHROPIC_API_KEY to doc-server External Secrets

### DIFF
--- a/infra/secret-store/doc-server-external-secrets.yaml
+++ b/infra/secret-store/doc-server-external-secrets.yaml
@@ -19,6 +19,8 @@ spec:
       data:
         # Expose OpenAI key required by the docs application
         OPENAI_API_KEY: "{{ .OPENAI_API_KEY }}"
+        # Anthropic API key for intelligent ingestion with Claude
+        ANTHROPIC_API_KEY: "{{ .ANTHROPIC_API_KEY }}"
         # Provide both keys for application compatibility
         # Keep original key that application expects
         VECTOR_DATABASE_URL: "{{ .VECTOR_DATABASE_URL | trimSuffix \"%\" }}"
@@ -30,6 +32,11 @@ spec:
     remoteRef:
       key: api-keys
       property: OPENAI_API_KEY
+  # Anthropic API Key from central api-keys secret
+  - secretKey: ANTHROPIC_API_KEY
+    remoteRef:
+      key: api-keys
+      property: ANTHROPIC_API_KEY
   # Vector Database URL from doc-server-config secret
   - secretKey: VECTOR_DATABASE_URL
     remoteRef:

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -10,7 +10,8 @@ pub fn get_tool_schemas() -> Value {
             get_intake_schema(),
             get_jobs_schema(),
             get_stop_job_schema(),
-            get_input_schema()
+            get_input_schema(),
+            get_intelligent_ingest_schema()
         ]
     })
 }
@@ -24,7 +25,8 @@ pub fn get_tool_schemas_with_config(agents: &HashMap<String, crate::AgentConfig>
             get_intake_schema(),
             get_jobs_schema(),
             get_stop_job_schema(),
-            get_input_schema()
+            get_input_schema(),
+            get_intelligent_ingest_schema()
         ]
     })
 }
@@ -228,6 +230,35 @@ fn get_input_schema() -> Value {
                 "user": {"type": "string", "description": "Optional user label (agents.platform/user) to route to active job"}
             },
             "required": ["text"]
+        }
+    })
+}
+
+fn get_intelligent_ingest_schema() -> Value {
+    json!({
+        "name": "intelligent_ingest",
+        "description": "Intelligently analyze a GitHub repository and ingest its documentation using Claude to determine optimal ingestion strategy",
+        "inputSchema": {
+            "type": "object",
+            "properties": {
+                "github_url": {
+                    "type": "string",
+                    "description": "GitHub repository URL to analyze and ingest (e.g., https://github.com/cilium/cilium)"
+                },
+                "doc_type": {
+                    "type": "string",
+                    "description": "Documentation type/category for storage (e.g., cilium, solana, rust). If not specified, Claude will determine it."
+                },
+                "doc_server_url": {
+                    "type": "string",
+                    "description": "Doc server URL for ingestion (default: http://doc-server-agent-docs-server.mcp.svc.cluster.local:80)"
+                },
+                "auto_execute": {
+                    "type": "boolean",
+                    "description": "Automatically execute the ingestion strategy without confirmation (default: false)"
+                }
+            },
+            "required": ["github_url"]
         }
     })
 }

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -237,7 +237,7 @@ fn get_input_schema() -> Value {
 fn get_intelligent_ingest_schema() -> Value {
     json!({
         "name": "intelligent_ingest",
-        "description": "Intelligently analyze a GitHub repository and ingest its documentation using Claude to determine optimal ingestion strategy. Uses model configured in cto-config.json (defaults.intelligent_ingest.model)",
+        "description": "Intelligently analyze a GitHub repository and ingest its documentation using Claude to determine optimal ingestion strategy. Currently supports GitHub repositories only. Uses model configured in cto-config.json (defaults.intelligent_ingest.model)",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -247,7 +247,7 @@ fn get_intelligent_ingest_schema() -> Value {
                 },
                 "doc_type": {
                     "type": "string",
-                    "description": "Documentation type/category for storage (e.g., cilium, solana, rust). If not specified, Claude will determine it."
+                    "description": "Documentation type/category for storage (e.g., cilium, solana, rust, ethereum, jupiter, meteora, raydium, ebpf, rust_best_practices, birdeye, talos)"
                 },
                 "doc_server_url": {
                     "type": "string",
@@ -258,7 +258,7 @@ fn get_intelligent_ingest_schema() -> Value {
                     "description": "Automatically execute the ingestion strategy without confirmation (default: false)"
                 }
             },
-            "required": ["github_url"]
+            "required": ["github_url", "doc_type"]
         }
     })
 }

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -237,7 +237,7 @@ fn get_input_schema() -> Value {
 fn get_intelligent_ingest_schema() -> Value {
     json!({
         "name": "intelligent_ingest",
-        "description": "Intelligently analyze a GitHub repository and ingest its documentation using Claude to determine optimal ingestion strategy",
+        "description": "Intelligently analyze a GitHub repository and ingest its documentation using Claude to determine optimal ingestion strategy. Uses model configured in cto-config.json (defaults.intelligent_ingest.model)",
         "inputSchema": {
             "type": "object",
             "properties": {
@@ -251,7 +251,7 @@ fn get_intelligent_ingest_schema() -> Value {
                 },
                 "doc_server_url": {
                     "type": "string",
-                    "description": "Doc server URL for ingestion (default: http://doc-server-agent-docs-server.mcp.svc.cluster.local:80)"
+                    "description": "Doc server URL for ingestion (default from config or http://doc-server-agent-docs-server.mcp.svc.cluster.local:80)"
                 },
                 "auto_execute": {
                     "type": "boolean",


### PR DESCRIPTION
## Summary
- Added ANTHROPIC_API_KEY to doc-server External Secrets configuration
- Enables intelligent documentation ingestion feature in cto-mcp toolset

## Changes
- Updated `infra/secret-store/doc-server-external-secrets.yaml` to include ANTHROPIC_API_KEY
- Key is sourced from central `api-keys` secret in secret-store namespace
- Added to both the data mapping and template output

## Testing
- Applied manually to verify External Secret syncs correctly
- Secret will be available as environment variable for doc-server pods

## Requirements
- Requires ANTHROPIC_API_KEY to exist in the `api-keys` secret in secret-store namespace

🤖 Generated with [Claude Code](https://claude.ai/code)