### PR TITLE
feat: mount Anthropic and OpenAI API keys to doc-server deployment

### DIFF
--- a/infra/gitops/applications/doc-server.yaml
+++ b/infra/gitops/applications/doc-server.yaml
@@ -33,6 +33,16 @@ spec:
           MCP_HOST: "0.0.0.0"
         secret:
           existingSecret: doc-server-secrets
+          # Explicitly mount API keys for documentation processing
+          env:
+            ANTHROPIC_API_KEY:
+              secretKeyRef:
+                name: doc-server-secrets
+                key: ANTHROPIC_API_KEY
+            OPENAI_API_KEY:
+              secretKeyRef:
+                name: doc-server-secrets
+                key: OPENAI_API_KEY
         migrations:
           serviceAccountName: default
           # Ensure chart uses correct binary path and migrate-only args


### PR DESCRIPTION
- Add explicit environment variable mounting for ANTHROPIC_API_KEY and OPENAI_API_KEY
- Both keys are sourced from doc-server-secrets (managed by External Secrets)
- Enables intelligent ingestion functionality with Claude API
- Ensures doc-server has access to required API keys for processing