### PR TITLE
fix: resolve Redis BRPOP command error in doc server worker

### DIFF
--- a/infra/gitops/applications/doc-server.yaml
+++ b/infra/gitops/applications/doc-server.yaml
@@ -31,6 +31,8 @@ spec:
           RUST_LOG: "info,doc_server=debug"
           PORT: "3001"
           MCP_HOST: "0.0.0.0"
+          # Redis configuration - point to Redis master, not Sentinel
+          REDIS_URL: "redis://redis.databases.svc.cluster.local:6379"
           # Embeddings configuration (env-based)
           OPENAI_BASE_URL: "https://api.openai.com/v1"
           OPENAI_EMBEDDING_MODEL: "text-embedding-3-large"

--- a/infra/gitops/databases/redis-service.yaml
+++ b/infra/gitops/databases/redis-service.yaml
@@ -1,0 +1,24 @@
+---
+# Redis Service for Redis Failover
+# This service exposes the Redis master for applications to connect to
+apiVersion: v1
+kind: Service
+metadata:
+  name: redis
+  namespace: databases
+  labels:
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/part-of: redis-failover
+    team: platform
+spec:
+  type: ClusterIP
+  ports:
+    - name: redis
+      port: 6379
+      targetPort: 6379
+      protocol: TCP
+  selector:
+    app.kubernetes.io/component: redis
+    app.kubernetes.io/name: redis
+    app.kubernetes.io/part-of: redis-failover


### PR DESCRIPTION
- Add Redis service manifest to expose Redis master on port 6379
- Update doc server configuration to connect to Redis master instead of Sentinel
- Fix 'unknown command BRPOP' error by connecting to proper Redis instance
- Sentinel (port 26379) doesn't support BRPOP, Redis master (port 6379) does