### PR TITLE
feat: add MCP environment variables to doc-server

### DIFF
--- a/infra/gitops/applications/doc-server.yaml
+++ b/infra/gitops/applications/doc-server.yaml
@@ -35,9 +35,16 @@ spec:
             value: "redis://redis.databases.svc.cluster.local:6379"
         env:
           # Keep chart defaults for non-secret settings
-          RUST_LOG: "info,doc_server=debug"
+          RUST_LOG: "info,doc_server=debug,mcp=debug"
           PORT: "3001"
           MCP_HOST: "0.0.0.0"
+          MCP_PORT: "3001"
+          # MCP configuration
+          MCP_LOCALHOST_ONLY: "false"
+          MCP_STRICT_ORIGIN_VALIDATION: "false"
+          MCP_REQUIRE_ORIGIN_HEADER: "false"
+          MCP_ENABLE_SSE: "true"
+          MCP_ENABLE_SSE_MIRROR: "false"
           # Redis configuration - point to Redis master, not Sentinel
           REDIS_URL: "redis://redis.databases.svc.cluster.local:6379"
           # Explicitly disable Sentinel usage in any client code


### PR DESCRIPTION
- Add MCP_LOCALHOST_ONLY=false for non-localhost connections
- Add MCP_STRICT_ORIGIN_VALIDATION=false for relaxed origin validation
- Add MCP_REQUIRE_ORIGIN_HEADER=false to make origin header optional
- Add MCP_ENABLE_SSE=true for Server-Sent Events support
- Add MCP_ENABLE_SSE_MIRROR=false to disable SSE mirroring
- Add MCP_PORT=3001 to match existing PORT configuration
- Update RUST_LOG to include mcp=debug for better MCP debugging