### PR TITLE
feat: add MCP_SSE_KEEPALIVE_SECS configuration

### DIFF
--- a/infra/gitops/applications/doc-server.yaml
+++ b/infra/gitops/applications/doc-server.yaml
@@ -45,6 +45,7 @@ spec:
           MCP_REQUIRE_ORIGIN_HEADER: "false"
           MCP_ENABLE_SSE: "true"
           MCP_ENABLE_SSE_MIRROR: "false"
+          MCP_SSE_KEEPALIVE_SECS: "10"
           # Redis configuration - point to Redis master, not Sentinel
           REDIS_URL: "redis://redis.databases.svc.cluster.local:6379"
           # Explicitly disable Sentinel usage in any client code


### PR DESCRIPTION
- Add MCP_SSE_KEEPALIVE_SECS=10 to set SSE keepalive interval to 10 seconds
- This helps maintain stable Server-Sent Events connections