### PR TITLE
Fix Play workflow controller startup and tool config pass-through

### DIFF
--- a/controller/src/tasks/code/templates.rs
+++ b/controller/src/tasks/code/templates.rs
@@ -517,26 +517,20 @@ impl CodeTemplateGenerator {
                         .local_servers
                         .as_ref()
                         .map(|local_servers_config| LocalServerConfigs {
-                            filesystem: LocalServerConfig {
-                                enabled: local_servers_config.filesystem.enabled,
-                                tools: local_servers_config.filesystem.tools.clone(),
-                                command: local_servers_config.filesystem.command.clone(),
-                                args: local_servers_config.filesystem.args.clone(),
-                                working_directory: local_servers_config
-                                    .filesystem
-                                    .working_directory
-                                    .clone(),
-                            },
-                            git: LocalServerConfig {
-                                enabled: local_servers_config.git.enabled,
-                                tools: local_servers_config.git.tools.clone(),
-                                command: local_servers_config.git.command.clone(),
-                                args: local_servers_config.git.args.clone(),
-                                working_directory: local_servers_config
-                                    .git
-                                    .working_directory
-                                    .clone(),
-                            },
+                            filesystem: local_servers_config.filesystem.as_ref().map(|fs| LocalServerConfig {
+                                enabled: fs.enabled,
+                                tools: fs.tools.clone(),
+                                command: fs.command.clone(),
+                                args: fs.args.clone(),
+                                working_directory: fs.working_directory.clone(),
+                            }),
+                            git: local_servers_config.git.as_ref().map(|git| LocalServerConfig {
+                                enabled: git.enabled,
+                                tools: git.tools.clone(),
+                                command: git.command.clone(),
+                                args: git.args.clone(),
+                                working_directory: git.working_directory.clone(),
+                            }),
                         });
 
                 return Ok(AgentTools {
@@ -557,7 +551,7 @@ impl CodeTemplateGenerator {
                 "memory_add_observations".to_string(),
             ],
             local_servers: Some(LocalServerConfigs {
-                filesystem: LocalServerConfig {
+                filesystem: Some(LocalServerConfig {
                     enabled: true,
                     tools: vec![
                         "read_file".to_string(),
@@ -569,8 +563,8 @@ impl CodeTemplateGenerator {
                     command: None,
                     args: None,
                     working_directory: None,
-                },
-                git: LocalServerConfig {
+                }),
+                git: Some(LocalServerConfig {
                     enabled: true,
                     tools: vec![
                         "git_status".to_string(),
@@ -581,7 +575,7 @@ impl CodeTemplateGenerator {
                     command: None,
                     args: None,
                     working_directory: None,
-                },
+                }),
             }),
         })
     }
@@ -715,20 +709,20 @@ mod tests {
                 "brave_web_search".to_string(),
             ],
             local_servers: Some(LocalServerConfigs {
-                filesystem: LocalServerConfig {
+                filesystem: Some(LocalServerConfig {
                     enabled: true,
                     tools: vec!["read_file".to_string(), "write_file".to_string()],
                     command: None,
                     args: None,
                     working_directory: None,
-                },
-                git: LocalServerConfig {
+                }),
+                git: Some(LocalServerConfig {
                     enabled: false,
                     tools: vec![],
                     command: None,
                     args: None,
                     working_directory: None,
-                },
+                }),
             }),
         };
 

--- a/controller/src/tasks/config.rs
+++ b/controller/src/tasks/config.rs
@@ -242,10 +242,12 @@ pub struct AgentTools {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 pub struct LocalServerConfigs {
     /// Filesystem server configuration
-    pub filesystem: LocalServerConfig,
+    #[serde(default)]
+    pub filesystem: Option<LocalServerConfig>,
 
     /// Git server configuration
-    pub git: LocalServerConfig,
+    #[serde(default)]
+    pub git: Option<LocalServerConfig>,
 }
 
 /// Configuration for a local MCP server

--- a/controller/src/tasks/docs/templates.rs
+++ b/controller/src/tasks/docs/templates.rs
@@ -251,38 +251,42 @@ impl DocsTemplateGenerator {
                 let mut local_servers_obj = serde_json::Map::new();
                 if let Some(ref ls) = tools.local_servers {
                     // filesystem - check if enabled before accessing fields
-                    if ls.filesystem.enabled {
-                        let mut fs_obj = serde_json::Map::new();
-                        if !ls.filesystem.tools.is_empty() {
-                            fs_obj.insert("tools".to_string(), json!(ls.filesystem.tools));
+                    if let Some(ref fs) = ls.filesystem {
+                        if fs.enabled {
+                            let mut fs_obj = serde_json::Map::new();
+                            if !fs.tools.is_empty() {
+                                fs_obj.insert("tools".to_string(), json!(fs.tools));
+                            }
+                            if let Some(cmd) = &fs.command {
+                                fs_obj.insert("command".to_string(), json!(cmd));
+                            }
+                            if let Some(args) = &fs.args {
+                                fs_obj.insert("args".to_string(), json!(args));
+                            }
+                            if let Some(wd) = &fs.working_directory {
+                                fs_obj.insert("workingDirectory".to_string(), json!(wd));
+                            }
+                            local_servers_obj.insert("filesystem".to_string(), Value::Object(fs_obj));
                         }
-                        if let Some(cmd) = &ls.filesystem.command {
-                            fs_obj.insert("command".to_string(), json!(cmd));
-                        }
-                        if let Some(args) = &ls.filesystem.args {
-                            fs_obj.insert("args".to_string(), json!(args));
-                        }
-                        if let Some(wd) = &ls.filesystem.working_directory {
-                            fs_obj.insert("workingDirectory".to_string(), json!(wd));
-                        }
-                        local_servers_obj.insert("filesystem".to_string(), Value::Object(fs_obj));
                     }
                     // git - check if enabled before accessing fields
-                    if ls.git.enabled {
-                        let mut g_obj = serde_json::Map::new();
-                        if !ls.git.tools.is_empty() {
-                            g_obj.insert("tools".to_string(), json!(ls.git.tools));
+                    if let Some(ref git) = ls.git {
+                        if git.enabled {
+                            let mut g_obj = serde_json::Map::new();
+                            if !git.tools.is_empty() {
+                                g_obj.insert("tools".to_string(), json!(git.tools));
+                            }
+                            if let Some(cmd) = &git.command {
+                                g_obj.insert("command".to_string(), json!(cmd));
+                            }
+                            if let Some(args) = &git.args {
+                                g_obj.insert("args".to_string(), json!(args));
+                            }
+                            if let Some(wd) = &git.working_directory {
+                                g_obj.insert("workingDirectory".to_string(), json!(wd));
+                            }
+                            local_servers_obj.insert("git".to_string(), Value::Object(g_obj));
                         }
-                        if let Some(cmd) = &ls.git.command {
-                            g_obj.insert("command".to_string(), json!(cmd));
-                        }
-                        if let Some(args) = &ls.git.args {
-                            g_obj.insert("args".to_string(), json!(args));
-                        }
-                        if let Some(wd) = &ls.git.working_directory {
-                            g_obj.insert("workingDirectory".to_string(), json!(wd));
-                        }
-                        local_servers_obj.insert("git".to_string(), Value::Object(g_obj));
                     }
                 }
 


### PR DESCRIPTION
## Summary

Fixes multiple issues preventing Play workflows from executing properly:

### Controller Startup Issue
- **Problem**: Controller failed to start with error `agents.rex.tools.localServers: missing field 'filesystem'`
- **Solution**: Made `LocalServerConfig` fields optional to handle empty `localServers: {}` configurations
- **Impact**: Controller can now parse client configs with empty local servers

### Missing Agent Configurations  
- **Problem**: Cleo and Tess agents missing from Helm values, causing CodeRun failures
- **Solution**: Added complete agent configurations matching client-side config structure
- **Impact**: All Play workflow agents (Rex, Cleo, Tess) now have proper tool access

### Tool Configuration Pass-Through
- **Problem**: Client-side tool customizations lost during Rex → Cleo → Tess workflow transitions
- **Solution**: Implemented annotation-based tool config preservation across workflow stages
- **Impact**: Client-side MCP tools now persist throughout entire Play workflow

### Updated Global Binary
- **Solution**: Updated global `cto-mcp` binary with tool extraction and workflow parameter passing
- **Impact**: Latest tool config pass-through functionality available globally

## Changes Made

### Controller (`controller/`)
- Made `filesystem` and `git` fields optional in `LocalServerConfigs` struct
- Updated docs and code workflows to handle optional local server configurations
- Fixed fallback logic to generate clientConfig from tools section when missing

### Helm Values (`infra/charts/controller/values.yaml`)  
- Added complete Cleo and Tess agent configurations
- Updated Rex tools to match client-side remote tools list
- Ensured consistent tool configurations across all agents

### MCP Client (`mcp/src/main.rs`)
- Extract tool configs for all three Play workflow agents
- Pass tool configs as workflow parameters (`*-tools`)
- Serialize client-side configurations for workflow annotation storage

### Workflow Template (`play-workflow-template.yaml`)
- Added tool config parameters and annotation storage
- Map appropriate tool configs to each workflow stage
- Preserve client-side customizations through workflow transitions

## Testing

- ✅ Controller builds successfully with new configuration structure
- ✅ All linting errors resolved  
- ✅ Global MCP binary updated and verified
- ✅ Configuration parsing handles empty `localServers: {}`

## Resolves

The original issue where Play workflow created CodeRun CRD but no associated job/pod appeared due to controller configuration failures.

This enables the full Play workflow: **Client MCP** → **Rex Implementation** → **Cleo Quality** → **Tess Testing** with proper tool access throughout.