### PR TITLE
fix: remove unnecessary conditions from play-workflow-template.yaml

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -165,7 +165,6 @@ spec:
           # Stage 2: Quality work
           - name: quality-work
             dependencies: [implementation-cycle, update-to-waiting-pr-created]
-            when: "{{`{{tasks.implementation-cycle.outputs.parameters.pr-number}}`}} != ''"
             template: agent-coderun
             arguments:
               parameters:
@@ -207,7 +206,6 @@ spec:
           # Stage 3: Testing work
           - name: testing-work
             dependencies: [wait-ready-for-qa]
-            when: "{{`{{tasks.implementation-cycle.outputs.parameters.pr-number}}`}} != ''"
             template: agent-coderun
             arguments:
               parameters:


### PR DESCRIPTION
This commit simplifies the play-workflow-template.yaml by removing redundant 'when' conditions in the quality-work and testing-work stages. This change enhances clarity and ensures that the workflow executes without unnecessary checks.