### PR TITLE
Feat/add-cli-docs-to-doc-server

### DIFF
--- a/cli-agnostic-platform/.taskmaster/docs/task-1/task.md
+++ b/cli-agnostic-platform/.taskmaster/docs/task-1/task.md
@@ -64,6 +64,15 @@ The 5D Labs Agent Platform already has a substantial CLI-agnostic implementation
 2. Document current CRD definitions and controller capabilities  
 3. Map out existing CLI integration patterns
 4. Identify supported vs. unsupported CLI types
+5. **Use docs MCP server to research CLI functionality**:
+   - **Codex Research**: Use `codex_query` for "installation requirements", "configuration patterns", "MCP integration"
+   - **OpenCode Research**: Use `opencode_query` for "setup guide", "MCP server support", "agent configuration"
+   - **OpenHands Research**: Use `openhands_query` for "CLI usage", "python dependencies", "automation capabilities"
+   - **Gemini Research**: Use `gemini_query` for "installation", "authentication", "model configuration"
+   - **Qwen Research**: Use `qwen_query` for "setup instructions", "model handling", "API configuration"
+   - **Grok Research**: Use `grok_query` for "installation", "X.AI integration", "MCP tools support"
+   - Document CLI-specific requirements, authentication patterns, and configuration formats
+   - Identify which CLIs support MCP natively vs. need wrapper integration
 
 ### Phase 2: MCP Server Assessment  
 1. Review `mcp/` Rust-based implementation
@@ -73,9 +82,18 @@ The 5D Labs Agent Platform already has a substantial CLI-agnostic implementation
 
 ### Phase 3: Container Infrastructure Testing
 1. Build and test each CLI Docker image
-2. Document configuration requirements per CLI
-3. Verify runtime functionality
-4. Identify broken or incomplete images
+2. **Research CLI requirements using docs MCP server**:
+   - `codex_query("docker installation requirements and runtime configuration")`
+   - `openhands_query("python virtualenv setup and CLI dependencies")`
+   - `gemini_query("npm installation and Google API authentication")`
+   - `qwen_query("installation via npm and model configuration patterns")`
+   - `grok_query("bun installation requirements and X.AI API setup")`
+   - `opencode_query("TypeScript CLI setup and MCP server integration")`
+   - Cross-reference docs research with actual Dockerfile implementations
+   - Document CLI-specific dependencies and environment requirements
+3. Document configuration requirements per CLI based on research
+4. Verify runtime functionality
+5. Identify broken or incomplete images
 
 ### Phase 4: Deployment Pipeline Review
 1. Analyze existing GitOps configurations
@@ -94,11 +112,15 @@ The 5D Labs Agent Platform already has a substantial CLI-agnostic implementation
 - Rust toolchain (1.70+) for code analysis
 - Kubernetes cluster access for deployment testing
 - GitHub Actions access for CI/CD review
+- **Docs MCP server access** for CLI documentation research
+- **Ingested CLI documentation** (Codex, OpenCode, OpenHands, Gemini, Qwen, Grok)
 
 ## Success Criteria
 - Complete documentation of current architecture
 - All CLI Docker images tested and status documented
 - Current MCP server capabilities documented
+- **CLI research completed using docs MCP server queries**
+- Cross-reference between CLI documentation and actual implementation
 - Gap analysis completed with prioritized recommendations
 - Clear roadmap for next development phases
 
@@ -106,6 +128,13 @@ The 5D Labs Agent Platform already has a substantial CLI-agnostic implementation
 - **Architecture Assessment Report**: Document current Rust controller capabilities
 - **MCP Server Analysis**: Review of existing Rust-based MCP implementation
 - **CLI Image Status Matrix**: Functional status of each CLI Docker image  
+- **CLI Research Report**: Analysis of each CLI's capabilities using docs MCP server queries
+  - Codex configuration patterns and requirements (via `codex_query`)
+  - OpenCode setup and usage patterns (via `opencode_query`)
+  - OpenHands automation capabilities (via `openhands_query`)
+  - Gemini integration approaches (via `gemini_query`)
+  - Qwen model handling (via `qwen_query`)
+  - Grok MCP tool integration (via `grok_query`)
 - **Deployment Pipeline Review**: Analysis of current GitOps setup
 - **Gap Analysis Document**: Prioritized list of missing functionality
 - **Development Roadmap**: Recommended next steps for CLI-agnostic platform

--- a/cli-agnostic-platform/.taskmaster/docs/task-1/task.md
+++ b/cli-agnostic-platform/.taskmaster/docs/task-1/task.md
@@ -1,135 +1,124 @@
-# Task 1: Initialize Project Structure and Dependencies
+# Task 1: Assess Current CLI-Agnostic Platform Implementation
 
 ## Overview
-Set up the foundational project structure with Rust workspace for controller, TypeScript for MCP integration, and Docker build infrastructure for multi-CLI support. This task establishes the foundation for the entire Multi-CLI Agent Platform project.
+Analyze and document the existing CLI-agnostic platform implementation to understand what capabilities already exist and what still needs to be built. This task provides a clear understanding of the current system architecture and identifies gaps for future development.
 
 ## Context
-The 5D Labs Agent Platform currently operates exclusively with Claude Code CLI. This task begins the implementation of CLI-agnostic support by establishing the proper project structure that will support 8 different CLI tools (Claude, Codex, Opencode, Gemini, Grok, Qwen, Cursor, OpenHands).
+The 5D Labs Agent Platform already has a substantial CLI-agnostic implementation with Rust-based controller, MCP server, and Docker images for multiple CLI tools (Claude, Codex, OpenCode, Gemini, Grok, Qwen, Cursor, OpenHands). This task assesses the current state to guide further development.
 
-## Technical Specification
+## Assessment Areas
 
-### 1. Rust Workspace Setup
-- **Location**: Root directory with `Cargo.toml`
-- **Structure**: Workspace with controller crate
-- **Dependencies**:
-  - `kube-rs v0.95.0` for Kubernetes client integration
-  - `tokio v1.41.0` for async runtime
-  - Additional Rust crates for CLI adapters
+### 1. Existing Rust Architecture Analysis
+- **Location**: `controller/` directory 
+- **Current State**: Examine existing Rust controller implementation
+- **Assessment Goals**:
+  - Document current CLI integration capabilities
+  - Identify which CLI types are supported
+  - Analyze CRD definitions and controller logic
+  - Review error handling and logging patterns
 
-### 2. Controller Implementation
-- **Path**: `controller/src/main.rs`
-- **Purpose**: Basic Kubernetes client initialization
-- **Features**:
-  - Kubernetes cluster connection
-  - CRD handling setup
-  - Error handling patterns
-
-### 3. MCP Integration Setup
+### 2. MCP Server Implementation Review
 - **Location**: `mcp/` directory
-- **Technology**: TypeScript/Node.js
-- **Dependencies**: `@modelcontextprotocol/sdk v1.0.4`
-- **Purpose**: Model Context Protocol integration layer
+- **Current State**: Rust-based MCP server (NO TypeScript)
+- **Assessment Goals**:
+  - Document current MCP protocol support
+  - Identify tool integration capabilities
+  - Review client connection handling
+  - Analyze performance and scalability
 
-### 4. Container Infrastructure
-- **Path**: `infra/images/`
-- **Structure**: Subdirectories for each CLI:
-  - `claude/` - Claude Code CLI
-  - `codex/` - OpenAI Codex CLI
-  - `opencode/` - Opencode CLI
-  - `gemini/` - Google Gemini CLI
-  - `grok/` - Grok CLI
-  - `qwen/` - Qwen CLI
-  - `cursor/` - Cursor CLI
-  - `openhands/` - OpenHands CLI
+### 3. Container Infrastructure Audit
+- **Location**: `infra/images/`
+- **Current State**: Multiple CLI Docker images exist
+- **Assessment Goals**:
+  - Verify which CLI images are functional:
+    - `claude/` - Claude Code CLI
+    - `codex/` - OpenAI Codex CLI
+    - `opencode/` - OpenCode CLI  
+    - `gemini/` - Google Gemini CLI
+    - `grok/` - Grok CLI
+    - `qwen/` - Qwen CLI
+    - `cursor/` - Cursor CLI
+    - `openhands/` - OpenHands CLI
+  - Test build processes and dependencies
+  - Document configuration requirements
 
-### 5. CI/CD Pipeline
-- **Path**: `.github/workflows/build-images.yml`
-- **Purpose**: Automated multi-arch container builds
-- **Features**:
-  - Docker buildx integration
-  - Multi-architecture support (amd64, arm64)
-  - Container registry push
+### 4. GitOps and Deployment Analysis
+- **Location**: `infra/gitops/`
+- **Current State**: ArgoCD applications exist
+- **Assessment Goals**:
+  - Review existing ArgoCD application configurations
+  - Document current deployment patterns
+  - Identify any missing automation
 
-### 6. Build System
-- **File**: Root `Makefile`
-- **Targets**:
-  - `build`: Build all components
-  - `test`: Run test suites
-  - `deploy`: Deploy to cluster
-  - `clean`: Clean build artifacts
+### 5. Build and CI/CD Evaluation
+- **Current State**: GitHub Actions workflows exist
+- **Assessment Goals**:
+  - Review existing automation pipelines
+  - Document build processes
+  - Identify gaps in testing/deployment
 
 ## Implementation Steps
 
-### Phase 1: Workspace Initialization
-1. Create root `Cargo.toml` with workspace configuration
-2. Initialize `controller/` directory with basic crate structure
-3. Set up initial dependencies in `controller/Cargo.toml`
+### Phase 1: Architecture Documentation
+1. Analyze existing `controller/` Rust implementation
+2. Document current CRD definitions and controller capabilities  
+3. Map out existing CLI integration patterns
+4. Identify supported vs. unsupported CLI types
 
-### Phase 2: MCP Setup
-1. Create `mcp/` directory with `package.json`
-2. Install TypeScript dependencies and MCP SDK
-3. Set up TypeScript configuration
+### Phase 2: MCP Server Assessment  
+1. Review `mcp/` Rust-based implementation
+2. Test MCP protocol functionality
+3. Document current tool integration capabilities
+4. Assess performance and identify bottlenecks
 
-### Phase 3: Container Infrastructure
-1. Create `infra/images/` directory structure
-2. Add placeholder Dockerfiles for each CLI
-3. Set up base image configurations
+### Phase 3: Container Infrastructure Testing
+1. Build and test each CLI Docker image
+2. Document configuration requirements per CLI
+3. Verify runtime functionality
+4. Identify broken or incomplete images
 
-### Phase 4: CI/CD Integration
-1. Create GitHub Actions workflow
-2. Configure Docker buildx for multi-arch builds
-3. Set up container registry integration
+### Phase 4: Deployment Pipeline Review
+1. Analyze existing GitOps configurations
+2. Test current ArgoCD application deployments
+3. Review CI/CD pipeline effectiveness
+4. Document manual deployment steps
 
-### Phase 5: Build System
-1. Create comprehensive Makefile
-2. Add development and deployment targets
-3. Configure git repository with appropriate .gitignore
+### Phase 5: Gap Analysis and Recommendations
+1. Create comprehensive current-state documentation
+2. Identify missing functionality
+3. Prioritize development needs
+4. Provide recommendations for next steps
 
 ## Dependencies
-- Docker and Docker buildx
-- Rust toolchain (1.70+)
-- Node.js (18+) and npm
-- Kubernetes cluster access
-- GitHub Actions environment
+- Docker and Docker buildx for image testing
+- Rust toolchain (1.70+) for code analysis
+- Kubernetes cluster access for deployment testing
+- GitHub Actions access for CI/CD review
 
 ## Success Criteria
-- `cargo check` passes for Rust workspace
-- `npm install` succeeds in MCP directory
-- Docker build infrastructure validates
-- GitHub Actions workflow can be tested locally
-- All Makefile targets execute correctly
+- Complete documentation of current architecture
+- All CLI Docker images tested and status documented
+- Current MCP server capabilities documented
+- Gap analysis completed with prioritized recommendations
+- Clear roadmap for next development phases
 
-## Files Created
-```
-├── Cargo.toml (workspace)
-├── controller/
-│   ├── Cargo.toml
-│   └── src/main.rs
-├── mcp/
-│   ├── package.json
-│   └── tsconfig.json
-├── infra/images/
-│   ├── claude/Dockerfile
-│   ├── codex/Dockerfile
-│   ├── opencode/Dockerfile
-│   ├── gemini/Dockerfile
-│   ├── grok/Dockerfile
-│   ├── qwen/Dockerfile
-│   ├── cursor/Dockerfile
-│   └── openhands/Dockerfile
-├── .github/workflows/build-images.yml
-├── Makefile
-└── .gitignore
-```
+## Deliverables
+- **Architecture Assessment Report**: Document current Rust controller capabilities
+- **MCP Server Analysis**: Review of existing Rust-based MCP implementation
+- **CLI Image Status Matrix**: Functional status of each CLI Docker image  
+- **Deployment Pipeline Review**: Analysis of current GitOps setup
+- **Gap Analysis Document**: Prioritized list of missing functionality
+- **Development Roadmap**: Recommended next steps for CLI-agnostic platform
 
 ## Next Steps
-After completion, this task enables:
-- Task 2: CLI-Aware Model Validation Framework
-- Task 3: CLI Adapter Trait System
-- Container builds for specific CLI implementations
+After completion, this assessment enables:
+- Informed development of missing CLI integration features
+- Prioritized bug fixes for broken CLI implementations
+- Enhanced MCP server capabilities where needed
+- Improved deployment automation
 
 ## Risk Mitigation
-- Version pin all dependencies to ensure reproducible builds
-- Use multi-stage Docker builds to optimize image sizes
-- Implement comprehensive error handling in controller
-- Set up automated security scanning for containers
+- Document current working functionality before making changes
+- Preserve existing functional CLI integrations during updates
+- Test current deployment processes before modifying them
+- Maintain backward compatibility with existing configurations

--- a/cli-agnostic-platform/.taskmaster/docs/task-2/acceptance-criteria.md
+++ b/cli-agnostic-platform/.taskmaster/docs/task-2/acceptance-criteria.md
@@ -1,369 +1,166 @@
-# Acceptance Criteria: CLI-Aware Model Validation Framework
+# Acceptance Criteria: Flexible CLI Model Configuration
 
 ## Functional Requirements
 
-### FR-1: Multi-Provider Model Validation
-**Requirement**: Support model validation for all CLI providers
-- [ ] Claude models validate: `claude-3-opus`, `claude-3.5-sonnet`, `claude-3-haiku`
-- [ ] Legacy Claude models work: `opus`, `sonnet`, `haiku`
-- [ ] OpenAI models validate: `gpt-4o`, `gpt-4-turbo`, `gpt-3.5-turbo`
-- [ ] Codex models validate: `gpt-5-codex`, `o1-preview`, `o3-mini`
-- [ ] Google models validate: `gemini-1.5-pro`, `gemini-2.0-flash`, `gemini-pro-vision`
-- [ ] Invalid models are properly rejected with helpful error messages
+### FR-1: User-Configured Model Support
+**Requirement**: Allow users to configure any model name without hardcoded validation
+- [ ] Accept any model string provided by user configuration
+- [ ] Pass model name directly to CLI without validation
+- [ ] Let each CLI handle model validation internally
+- [ ] Support custom/local models (e.g., Ollama, custom endpoints)
+- [ ] Provide helpful error messages from CLI responses when models fail
 
 **Verification**:
 ```rust
 #[tokio::test]
-async fn test_all_provider_validation() {
-    let catalog = ModelCatalog::new().await;
+async fn test_flexible_model_configuration() {
+    let config = CLIConfig::new();
 
-    // Claude models
-    assert!(catalog.validate("claude-3-opus", CLIType::Claude).await.is_ok());
-    assert!(catalog.validate("opus", CLIType::Claude).await.is_ok());
-
-    // OpenAI models
-    assert!(catalog.validate("gpt-4o", CLIType::Codex).await.is_ok());
-    assert!(catalog.validate("o3-mini", CLIType::Codex).await.is_ok());
-
-    // Google models
-    assert!(catalog.validate("gemini-1.5-pro", CLIType::Gemini).await.is_ok());
-
-    // Invalid models
-    assert!(catalog.validate("invalid-model", CLIType::Claude).await.is_err());
+    // Any model name should be accepted
+    assert!(config.set_model("claude-3-5-sonnet-20241022", CLIType::Claude).is_ok());
+    assert!(config.set_model("gpt-4o-2024-08-06", CLIType::Codex).is_ok());
+    assert!(config.set_model("gemini-2.0-flash-exp", CLIType::Gemini).is_ok());
+    assert!(config.set_model("llama3.1:70b", CLIType::Custom).is_ok());
+    assert!(config.set_model("my-custom-model", CLIType::Custom).is_ok());
+    
+    // Model validation happens at CLI level, not in our code
+    // We just pass through whatever the user configured
 }
 ```
 
 ### FR-2: Backward Compatibility
-**Requirement**: Existing Claude agents continue working unchanged
-- [ ] Original `validate_model_name()` behavior preserved for Claude models
-- [ ] No changes to existing Claude agent configurations required
-- [ ] Legacy model names (`opus`, `sonnet`, `haiku`) continue working
-- [ ] Error messages remain consistent for Claude-only scenarios
+**Requirement**: Existing configurations continue working without modification
+- [ ] Accept any model name from existing configurations
+- [ ] No breaking changes to configuration file formats
+- [ ] Pass through model names to CLI without interference
+- [ ] Preserve existing behavior for all CLI types
 
 **Verification**:
 ```rust
 #[tokio::test]
 async fn test_backward_compatibility() {
-    // Test exact same behavior as original function
-    let result = validate_model_for_cli("opus", CLIType::Claude, &catalog).await;
-    assert!(result.is_ok());
-
-    let result = validate_model_for_cli("invalid", CLIType::Claude, &catalog).await;
-    assert!(result.is_err());
+    // Existing configurations should work without modification
+    let config = AgentConfig::load_existing();
+    
+    // Any model name should be accepted and passed through
+    assert!(config.model_name().is_some());
+    assert!(config.validate().is_ok()); // Only validates config structure, not model names
+    
+    // Model validation happens at runtime by the CLI itself
 }
 ```
 
-### FR-3: Fuzzy Matching and Suggestions
-**Requirement**: Provide helpful suggestions for invalid models
-- [ ] Common typos are detected and corrected
-- [ ] Levenshtein distance algorithm for similarity matching
-- [ ] Suggestions provided when confidence > 0.7 threshold
-- [ ] Case-insensitive matching for model names
-- [ ] Abbreviation expansion (e.g., "gpt4" -> "gpt-4")
+### FR-3: Configuration Flexibility
+**Requirement**: Support diverse model configuration patterns
+- [ ] Environment variable model override support
+- [ ] CLI-specific model configuration sections
+- [ ] Default model fallback when none specified
+- [ ] Configuration validation for format, not content
+- [ ] Runtime model discovery through CLI introspection
 
 **Verification**:
 ```rust
 #[tokio::test]
-async fn test_fuzzy_matching() {
-    let catalog = ModelCatalog::new().await;
+async fn test_configuration_flexibility() {
+    let mut config = CLIConfig::new();
 
-    let result = catalog.validate("claud-opus", CLIType::Claude).await;
-    assert!(result.is_err());
+    // Environment variable override
+    std::env::set_var("CLAUDE_MODEL", "claude-3-5-sonnet-20241022");
+    config.load_env_overrides();
+    assert_eq!(config.model_for_cli(CLIType::Claude), Some("claude-3-5-sonnet-20241022"));
 
-    if let Err(ValidationError::ModelNotSupported { suggestion: Some(suggestion), .. }) = result {
-        assert_eq!(suggestion, "claude-3-opus");
-    }
+    // CLI-specific configuration
+    config.set_default_model(CLIType::Gemini, "gemini-2.0-flash-exp");
+    assert!(config.has_default_for_cli(CLIType::Gemini));
 }
 ```
 
-### FR-4: Model Capabilities Metadata
-**Requirement**: Provide comprehensive model capability information
-- [ ] Context window size for each model
-- [ ] Streaming support detection
-- [ ] Multimodal capabilities (vision, audio)
-- [ ] Function calling support
-- [ ] Cost per token information
-- [ ] Rate limiting information
+### FR-4: CLI Integration
+**Requirement**: Seamless integration with each CLI's model handling
+- [ ] Pass model configuration directly to CLI without modification
+- [ ] Support CLI-specific model parameter formats
+- [ ] Handle CLI-specific authentication patterns
+- [ ] Preserve CLI-native error messages
+- [ ] Support CLI auto-discovery of available models
 
 **Verification**:
 ```rust
 #[tokio::test]
-async fn test_model_capabilities() {
-    let catalog = ModelCatalog::new().await;
-    let caps = catalog.get_model_capabilities("claude-3-opus").unwrap();
-
-    assert_eq!(caps.max_context_tokens, 200_000);
-    assert!(caps.supports_streaming);
-    assert!(!caps.supports_multimodal);
-}
-```
-
-### FR-5: High-Performance Caching
-**Requirement**: Efficient caching for repeated validations
-- [ ] LRU cache with configurable TTL
-- [ ] Thread-safe concurrent access
-- [ ] Cache hit ratio >80% for repeated validations
-- [ ] Memory usage <100MB for complete catalog
-- [ ] Cache invalidation when model catalogs update
-
-**Verification**:
-```rust
-#[tokio::test]
-async fn test_caching_performance() {
-    let catalog = ModelCatalog::new().await;
-
-    // First validation (cache miss)
-    let start = Instant::now();
-    catalog.validate("claude-3-opus", CLIType::Claude).await.unwrap();
-    let first_duration = start.elapsed();
-
-    // Second validation (cache hit)
-    let start = Instant::now();
-    catalog.validate("claude-3-opus", CLIType::Claude).await.unwrap();
-    let cached_duration = start.elapsed();
-
-    assert!(cached_duration < first_duration / 2);
+async fn test_cli_integration() {
+    let cli_runner = CLIRunner::new(CLIType::Claude);
+    
+    // Model name is passed through unchanged
+    let config = cli_runner.build_config("any-model-name").await;
+    assert!(config.contains("any-model-name"));
+    
+    // CLI handles its own model validation and error reporting
+    let result = cli_runner.execute_with_model("custom-model").await;
+    // We don't validate the model - let the CLI decide if it's valid
 }
 ```
 
 ## Non-Functional Requirements
 
 ### NFR-1: Performance
-**Requirement**: High-performance validation suitable for production
-- [ ] Validation latency <10ms per request
-- [ ] Support 1000+ concurrent validations
-- [ ] Memory usage <100MB for complete model catalog
-- [ ] CPU usage <5% under normal load
-- [ ] No blocking operations in hot path
-
-**Verification**:
-```rust
-#[tokio::test]
-async fn test_performance_requirements() {
-    let catalog = ModelCatalog::new().await;
-    let start = Instant::now();
-
-    // Test 1000 concurrent validations
-    let tasks: Vec<_> = (0..1000).map(|_| {
-        let catalog = catalog.clone();
-        tokio::spawn(async move {
-            catalog.validate("claude-3-opus", CLIType::Claude).await
-        })
-    }).collect();
-
-    for task in tasks {
-        task.await.unwrap().unwrap();
-    }
-
-    let duration = start.elapsed();
-    assert!(duration < Duration::from_secs(1)); // All validations in <1s
-}
-```
+**Requirement**: Configuration handling should be fast and lightweight
+- [ ] Model configuration loading <10ms
+- [ ] No external API calls for model validation
+- [ ] Minimal memory footprint for configuration storage
+- [ ] Concurrent configuration access support
 
 ### NFR-2: Reliability
-**Requirement**: Robust error handling and recovery
-- [ ] Graceful degradation when external APIs unavailable
-- [ ] Circuit breaker pattern for failing providers
-- [ ] Automatic retry with exponential backoff
-- [ ] Comprehensive error types with actionable messages
-- [ ] No panics under any input conditions
+**Requirement**: Robust configuration handling
+- [ ] Graceful handling of malformed model names
+- [ ] Fallback to default models when configured model fails
+- [ ] Proper error propagation from CLI tools
+- [ ] Configuration persistence across restarts
 
-### NFR-3: Observability
-**Requirement**: Comprehensive monitoring and debugging
-- [ ] Metrics for validation success/failure rates
-- [ ] Latency percentiles (p50, p95, p99)
-- [ ] Cache hit/miss ratios
-- [ ] Provider availability metrics
-- [ ] Structured logging with correlation IDs
-
-### NFR-4: Security
-**Requirement**: Secure handling of model information
-- [ ] No sensitive model data logged or cached insecurely
-- [ ] Input validation prevents injection attacks
-- [ ] Rate limiting prevents abuse
-- [ ] Audit logging for security events
-
-## Test Cases
-
-### TC-1: Basic Validation Flow
-**Scenario**: Validate different models across CLI types
-```rust
-async fn test_basic_validation() {
-    let catalog = ModelCatalog::new().await;
-
-    // Valid cases
-    assert!(catalog.validate("claude-3-opus", CLIType::Claude).await.is_ok());
-    assert!(catalog.validate("gpt-4", CLIType::Codex).await.is_ok());
-    assert!(catalog.validate("gemini-pro", CLIType::Gemini).await.is_ok());
-
-    // Invalid cases
-    assert!(catalog.validate("claude-3-opus", CLIType::Codex).await.is_err());
-    assert!(catalog.validate("gpt-4", CLIType::Claude).await.is_err());
-}
-```
-
-### TC-2: Concurrent Validation Load Test
-**Scenario**: Multiple threads validating simultaneously
-```rust
-async fn test_concurrent_load() {
-    let catalog = Arc::new(ModelCatalog::new().await);
-    let mut handles = vec![];
-
-    for _ in 0..100 {
-        let catalog = catalog.clone();
-        handles.push(tokio::spawn(async move {
-            for _ in 0..10 {
-                catalog.validate("claude-3-opus", CLIType::Claude).await.unwrap();
-            }
-        }));
-    }
-
-    for handle in handles {
-        handle.await.unwrap();
-    }
-}
-```
-
-### TC-3: Error Recovery Scenarios
-**Scenario**: Handle provider unavailability gracefully
-```rust
-async fn test_provider_failure() {
-    let catalog = ModelCatalog::with_failing_provider().await;
-
-    match catalog.validate("failing-model", CLIType::Unknown).await {
-        Err(ValidationError::ProviderUnavailable { retry_after, .. }) => {
-            assert!(retry_after.is_some());
-        }
-        _ => panic!("Expected provider unavailable error"),
-    }
-}
-```
-
-### TC-4: Cache Effectiveness
-**Scenario**: Verify cache improves performance
-```rust
-async fn test_cache_effectiveness() {
-    let catalog = ModelCatalog::new().await;
-
-    // Prime cache
-    for _ in 0..10 {
-        catalog.validate("claude-3-opus", CLIType::Claude).await.unwrap();
-    }
-
-    let metrics = catalog.get_cache_metrics();
-    assert!(metrics.hit_ratio > 0.8);
-}
-```
-
-### TC-5: Fuzzy Matching Accuracy
-**Scenario**: Test suggestion quality
-```rust
-async fn test_suggestion_quality() {
-    let catalog = ModelCatalog::new().await;
-
-    let test_cases = vec![
-        ("claud-opus", Some("claude-3-opus")),
-        ("gpt4", Some("gpt-4")),
-        ("gemni-pro", Some("gemini-pro")),
-        ("completely-wrong-model", None),
-    ];
-
-    for (input, expected) in test_cases {
-        let result = catalog.validate(input, CLIType::Claude).await;
-        match result {
-            Err(ValidationError::ModelNotSupported { suggestion, .. }) => {
-                assert_eq!(suggestion, expected);
-            }
-            _ => panic!("Expected validation error with suggestion"),
-        }
-    }
-}
-```
-
-## Quality Gates
-
-### Code Quality
-- [ ] All code passes `cargo clippy` with zero warnings
-- [ ] Code coverage >90% for validation logic
-- [ ] No unsafe code blocks
-- [ ] All public APIs have comprehensive documentation
-
-### Performance Benchmarks
-- [ ] Validation latency <10ms (p99)
-- [ ] Cache hit ratio >80% after warmup
-- [ ] Memory usage stable under load
-- [ ] No memory leaks in long-running tests
-
-### Security Scanning
-- [ ] No SQL injection vulnerabilities
-- [ ] No buffer overflow potential
-- [ ] Rate limiting prevents DoS
-- [ ] Audit logging captures security events
-
-## Edge Cases and Error Scenarios
-
-### EC-1: Malformed Input
-**Scenario**: Handle invalid model name formats
-- Empty strings, null bytes, extremely long names
-**Expected**: Clear validation error with safe handling
-
-### EC-2: Provider API Failures
-**Scenario**: External model catalog APIs are down
-**Expected**: Use cached data or fallback validation
-
-### EC-3: Memory Pressure
-**Scenario**: System under memory pressure
-**Expected**: Cache eviction works properly, no OOM
-
-### EC-4: Race Conditions
-**Scenario**: Concurrent cache updates and reads
-**Expected**: Thread-safe operations with no data corruption
-
-### EC-5: Configuration Changes
-**Scenario**: Model catalog updates during runtime
-**Expected**: Hot-reload without service interruption
+### NFR-3: Maintainability
+**Requirement**: Simple, maintainable model handling
+- [ ] No hardcoded model lists to maintain
+- [ ] CLI-agnostic configuration structure
+- [ ] Clear separation between configuration and execution
+- [ ] Minimal code complexity for model handling
 
 ## Integration Requirements
 
-### IR-1: MCP Server Integration
-**Requirement**: Seamless replacement of existing validation
-- [ ] Drop-in replacement for `validate_model_name()`
-- [ ] No changes required to calling code
-- [ ] Maintains exact error behavior for Claude models
-- [ ] Adds new CLI support transparently
+### IR-1: CLI Compatibility
+**Requirement**: Work with each CLI's native model handling
+- [ ] Claude: Support any Claude model identifier
+- [ ] Codex: Support any OpenAI model identifier  
+- [ ] Gemini: Support any Google model identifier
+- [ ] Grok: Support any X.AI model identifier
+- [ ] Qwen: Support any Qwen model identifier
+- [ ] OpenHands: Support any configured model
+- [ ] OpenCode: Support any configured model
+- [ ] Custom: Support any custom model endpoint
 
-### IR-2: Configuration System
-**Requirement**: Configurable validation behavior
-- [ ] External model definition files supported
-- [ ] Per-CLI provider configuration
-- [ ] Cache size and TTL configuration
-- [ ] Feature flags for new providers
+### IR-2: Error Handling
+**Requirement**: Proper error handling without model validation
+- [ ] Configuration format errors are caught early
+- [ ] Model runtime errors are reported clearly
+- [ ] CLI-specific error messages are preserved
+- [ ] Fallback behavior when models are unavailable
 
-### IR-3: Monitoring Integration
-**Requirement**: Integration with existing observability
-- [ ] Prometheus metrics export
-- [ ] Structured logging compatible with existing system
-- [ ] Health check endpoints
-- [ ] Performance dashboard support
+## Success Criteria
 
-## Definition of Done
-Task 2 is considered complete when:
-- [ ] All functional requirements are implemented and tested
-- [ ] Performance requirements are met under load
-- [ ] Backward compatibility is verified with existing agents
-- [ ] Security requirements are satisfied
-- [ ] Integration with MCP server is complete
-- [ ] Comprehensive test suite passes
-- [ ] Documentation is complete
-- [ ] Code review approved
-- [ ] Production deployment successful
-- [ ] Monitoring shows healthy metrics
+### Primary Goals
+- [ ] **Zero Hardcoded Models**: No model names in source code
+- [ ] **User Freedom**: Users can configure any model they want
+- [ ] **CLI Native**: Each CLI handles its own model validation
+- [ ] **Backward Compatible**: Existing configurations continue working
 
-## Rollback Criteria
-Immediate rollback if:
-- Existing Claude agents fail validation
-- Performance regression >50% vs baseline
-- Memory usage >200MB sustained
-- Error rate >1% for valid models
-- Security vulnerabilities discovered
-- Availability drops below 99.9%
+### Verification Checklist
+- [ ] All existing Claude configurations work unchanged
+- [ ] New CLI types can be added without code changes
+- [ ] Model names are passed through without modification
+- [ ] Configuration validation only checks structure, not content
+- [ ] Runtime errors come from CLI tools, not our validation
+
+### Performance Benchmarks
+- [ ] Configuration loading: <10ms
+- [ ] Model parameter passing: <1ms overhead
+- [ ] Memory usage: <10MB for all CLI configurations
+- [ ] Startup time: No additional delay for model handling
+
+This approach ensures maximum flexibility while maintaining simplicity and reliability.

--- a/cli-agnostic-platform/.taskmaster/docs/task-2/task.md
+++ b/cli-agnostic-platform/.taskmaster/docs/task-2/task.md
@@ -1,14 +1,15 @@
-# Task 2: Implement CLI-Aware Model Validation Framework
+# Task 2: Implement Flexible CLI Model Configuration
 
 ## Overview
-Refactor the hard-coded `validate_model_name()` function to support all CLI providers with extensible validation patterns and comprehensive model catalog. This is a critical blocker that must be resolved before any multi-CLI integration work can proceed.
+Remove hardcoded model validation and implement a flexible configuration system that allows users to specify any model for any CLI. Each CLI will handle its own model validation, eliminating the need for maintaining hardcoded model lists in our codebase.
 
 ## Context
-The current validation system in `/mcp/src/main.rs:validate_model_name()` is hard-coded for Claude models only, immediately rejecting any non-Claude models like `gpt-5-codex` or `o3`. This creates a complete blocker for integrating other CLI providers and must be addressed as the highest priority technical risk.
+The current system has hardcoded Claude-only model validation that blocks other CLI providers. Instead of expanding this validation to include more hardcoded models, we should eliminate the validation entirely and let each CLI handle model compatibility on its own.
 
 ## Technical Specification
 
 ### 1. Current Validation Problem
+The system currently rejects any non-Claude models:
 ```rust
 fn validate_model_name(model: &str) -> Result<()> {
     if !model.starts_with("claude-") && !["opus", "sonnet", "haiku"].contains(&model) {
@@ -21,185 +22,202 @@ fn validate_model_name(model: &str) -> Result<()> {
 }
 ```
 
-### 2. New Trait-Based Architecture
+### 2. New Pass-Through Architecture
+Replace validation with flexible configuration:
 ```rust
-pub trait ModelValidator {
-    async fn validate_model(&self, model: &str, cli_type: CLIType) -> Result<ValidatedModel>;
-    fn get_supported_models(&self) -> Vec<String>;
-    fn suggest_correction(&self, invalid_model: &str) -> Option<String>;
-    fn get_model_capabilities(&self, model: &str) -> Option<ModelCapabilities>;
+pub struct CLIModelConfig {
+    pub model_name: String,
+    pub cli_type: CLIType,
+    pub custom_parameters: HashMap<String, String>,
+}
+
+impl CLIModelConfig {
+    pub fn new(model_name: String, cli_type: CLIType) -> Self {
+        Self {
+            model_name,
+            cli_type,
+            custom_parameters: HashMap::new(),
+        }
+    }
+    
+    // No validation - just pass through to CLI
+    pub fn validate_format(&self) -> Result<()> {
+        // Only validate configuration structure, not model names
+        if self.model_name.is_empty() {
+            return Err(anyhow!("Model name cannot be empty"));
+        }
+        Ok(())
+    }
 }
 ```
 
-### 3. Provider-Specific Validators
+### 3. CLI-Native Model Handling
+Instead of provider-specific validators, let each CLI handle its own models:
 
-#### Claude Model Validator
-- **Patterns**: `claude-3-opus`, `claude-3.5-sonnet`, `claude-3-haiku`
-- **Legacy Support**: `opus`, `sonnet`, `haiku`
-- **Version Handling**: Semantic versioning support
-- **Context Windows**: 200K-1M tokens depending on model
+#### Philosophy: Trust the CLI
+- **No Hardcoded Lists**: Zero model names in source code  
+- **CLI Responsibility**: Each CLI validates its own supported models
+- **User Freedom**: Users can configure any model identifier
+- **Runtime Validation**: Model validity checked when CLI executes
 
-#### OpenAI Model Validator
-- **Patterns**: `gpt-4o`, `gpt-4-turbo`, `gpt-3.5-turbo`
-- **Codex Models**: `gpt-5-codex`, `o1-preview`, `o3-mini`
-- **Version Support**: Model version suffixes
-- **Context Windows**: 8K-128K tokens
-
-#### Google Model Validator
-- **Patterns**: `gemini-1.5-pro`, `gemini-2.0-flash`, `gemini-pro-vision`
-- **Multimodal Support**: Vision and text capabilities
-- **Context Windows**: Up to 2M tokens
-- **Streaming Support**: Real-time responses
-
-### 4. Model Catalog System
+#### Implementation Approach
 ```rust
-pub struct ModelCatalog {
-    providers: HashMap<CLIType, Box<dyn ModelValidator>>,
-    cache: Arc<RwLock<LruCache<String, ValidatedModel>>>,
-    last_updated: Instant,
+pub struct CLIModelHandler {
+    pub cli_type: CLIType,
+    pub model_config: String,
+    pub environment: HashMap<String, String>,
+}
+
+impl CLIModelHandler {
+    pub fn new(cli_type: CLIType, model_config: String) -> Self {
+        Self {
+            cli_type,
+            model_config,
+            environment: HashMap::new(),
+        }
+    }
+    
+    // Pass through model config without validation
+    pub fn prepare_cli_args(&self) -> Vec<String> {
+        match self.cli_type {
+            CLIType::Claude => vec!["--model".to_string(), self.model_config.clone()],
+            CLIType::Codex => vec!["--model".to_string(), self.model_config.clone()],
+            CLIType::Gemini => vec!["--model".to_string(), self.model_config.clone()],
+            // Each CLI gets its model config passed through unchanged
+            _ => vec!["--model".to_string(), self.model_config.clone()],
+        }
+    }
 }
 ```
 
-Features:
-- Registry of valid models per CLI
-- Version support with deprecation warnings
-- Capability metadata (context window, multimodal, streaming)
-- Performance caching with TTL
-- Fuzzy matching for typo correction
-
-### 5. Enhanced Validation Features
-
-#### Fuzzy Matching
-- Levenshtein distance algorithm for typo detection
-- Common abbreviation expansions
-- Case-insensitive matching
-- Suggestion system for invalid models
-
-#### Model Capabilities
+### 4. Configuration Management
+Simple configuration structure without hardcoded models:
 ```rust
-pub struct ModelCapabilities {
-    pub max_tokens: u32,
-    pub supports_streaming: bool,
-    pub supports_multimodal: bool,
-    pub supports_tools: bool,
-    pub cost_per_token: Option<f64>,
-    pub deprecated: bool,
+pub struct CLIConfiguration {
+    pub default_models: HashMap<CLIType, String>,
+    pub environment_overrides: HashMap<String, String>,
+    pub cli_specific_params: HashMap<CLIType, HashMap<String, String>>,
+}
+
+impl CLIConfiguration {
+    pub fn get_model_for_cli(&self, cli_type: CLIType) -> Option<&String> {
+        // Check environment override first
+        let env_key = format!("{}_MODEL", cli_type.as_str().to_uppercase());
+        if let Ok(env_model) = std::env::var(&env_key) {
+            return Some(&env_model);
+        }
+        
+        // Fall back to default
+        self.default_models.get(&cli_type)
+    }
 }
 ```
 
 ## Implementation Steps
 
-### Phase 1: Core Framework
-1. Create `controller/src/cli/validation.rs` module
-2. Define `ModelValidator` trait with all required methods
-3. Implement base validation functionality
-4. Add comprehensive error types for validation failures
+### Phase 1: Remove Validation Logic
+1. Locate and remove `validate_model_name()` function
+2. Update all callers to accept any model string
+3. Remove hardcoded model constants and lists
+4. Add simple format validation (non-empty string only)
 
-### Phase 2: Provider Validators
-1. Implement `ClaudeModelValidator` with existing patterns
-2. Create `OpenAIModelValidator` for GPT and Codex models
-3. Build `GoogleModelValidator` for Gemini models
-4. Add extensible framework for future providers
+### Phase 2: Configuration Pass-Through
+1. Create `CLIModelConfig` structure for flexible configuration
+2. Implement model parameter passing to CLI commands
+3. Add environment variable override support
+4. Update configuration loading to accept any model names
 
-### Phase 3: Model Catalog
-1. Design `ModelCatalog` struct with provider registry
-2. Implement caching layer with LRU cache
-3. Add model capability metadata system
-4. Create fuzzy matching for error suggestions
+### Phase 3: Error Handling
+1. Remove model validation errors from our code
+2. Capture and forward CLI-specific model errors
+3. Implement proper error propagation from CLI processes
+4. Add helpful error context without model validation
 
 ### Phase 4: Integration
-1. Replace existing `validate_model_name()` function
-2. Update MCP server to use new validation system
-3. Add configuration for model catalog updates
-4. Implement telemetry for validation metrics
+1. Replace existing `validate_model_name()` function with pass-through
+2. Update MCP server to accept any model configuration
+3. Remove hardcoded model constants and validation logic
+4. Test with various CLI model configurations
 
-### Phase 5: Testing & Optimization
-1. Comprehensive unit tests for all validators
-2. Performance testing with concurrent validation
-3. Integration testing with mock CLI responses
-4. Load testing with 1000+ concurrent requests
+### Phase 5: Testing & Verification
+1. Test that any model string is accepted in configuration
+2. Verify model parameters are passed to CLI unchanged
+3. Test environment variable override functionality
+4. Verify CLI-specific error handling works properly
 
 ## Dependencies
-- Current MCP server codebase
-- CLI type definitions (from Task 3)
-- Error handling framework
-- Caching library (LRU cache)
-- Async runtime (tokio)
+- Current MCP server codebase (Rust-based)
+- CLI type definitions
+- Basic error handling framework
+- Standard Rust HashMap for configuration storage
 
 ## Success Criteria
-- All CLI models validate correctly
-- Performance: <10ms per validation
-- Fuzzy matching suggests correct alternatives
-- Cache hit ratio >80% for repeated validations
-- Zero false positives/negatives in validation
-- Backward compatibility with existing Claude models
+- Any model name is accepted in configuration
+- Model strings are passed to CLI without modification
+- Environment variables can override default models
+- CLI-specific errors are properly forwarded
+- Zero hardcoded model names in source code
+- Backward compatibility with existing configurations maintained
 
 ## Files Created/Modified
 ```
-controller/src/cli/
-├── validation.rs (new)
-├── model_catalog.rs (new)
-└── validators/
-    ├── claude.rs (new)
-    ├── openai.rs (new)
-    ├── google.rs (new)
-    └── mod.rs (new)
-
 mcp/src/
-├── main.rs (modified - replace validate_model_name)
-└── validation/ (new)
-    ├── types.rs (new)
-    └── error.rs (new)
+├── main.rs (modified - remove validate_model_name function)
+└── config.rs (modified - add flexible model configuration)
+
+controller/src/cli/
+└── model_config.rs (new - simple model pass-through logic)
 ```
 
 ## Risk Mitigation
 
 ### Backward Compatibility
-- Maintain exact same behavior for existing Claude models
-- Add deprecation warnings before removing legacy support
-- Provide migration path for configurations
+- Ensure all existing configurations continue working unchanged
+- No breaking changes to configuration APIs
+- Preserve CLI-specific behavior patterns
 
-### Performance
-- Implement comprehensive caching strategy
-- Use async validation where possible
-- Add circuit breakers for external API calls
-- Profile and optimize critical paths
+### Error Handling
+- Proper error propagation from CLI tools to users
+- Clear distinction between configuration errors and runtime errors
+- Graceful handling of CLI-specific authentication failures
 
-### Extensibility
-- Plugin-based architecture for new providers
-- Configuration-driven model definitions
-- Version-aware validation rules
-- Hot-reloading of model catalogs
+### Configuration Security
+- Input validation for configuration format (not content)
+- Protection against command injection in model parameters
+- Secure handling of environment variable overrides
 
 ## Testing Strategy
 ```rust
 #[cfg(test)]
 mod tests {
     #[tokio::test]
-    async fn test_claude_models() {
-        // Test all Claude model patterns
+    async fn test_any_model_accepted() {
+        // Test that any model string is accepted
+        let config = CLIModelConfig::new("any-model".to_string(), CLIType::Claude);
+        assert!(config.validate_format().is_ok());
     }
 
     #[tokio::test]
-    async fn test_openai_models() {
-        // Test GPT and Codex models
+    async fn test_model_passthrough() {
+        // Test model parameters are passed unchanged to CLI
+        let handler = CLIModelHandler::new(CLIType::Gemini, "custom-model".to_string());
+        let args = handler.prepare_cli_args();
+        assert!(args.contains(&"custom-model".to_string()));
     }
 
     #[tokio::test]
-    async fn test_fuzzy_matching() {
-        // Test typo correction
-    }
-
-    #[tokio::test]
-    async fn test_concurrent_validation() {
-        // Performance under load
+    async fn test_env_variable_override() {
+        // Test environment variable model overrides
+        std::env::set_var("CLAUDE_MODEL", "test-model");
+        let config = CLIConfiguration::new();
+        assert_eq!(config.get_model_for_cli(CLIType::Claude), Some(&"test-model".to_string()));
     }
 }
 ```
 
 ## Next Steps
 After completion enables:
-- Task 3: CLI Adapter Trait System (can use validated models)
+- Task 3: CLI Adapter Trait System (can use any configured models)
 - All subsequent CLI integrations (Codex, Opencode, Gemini)
 - Model capability-based routing
 - Cost optimization based on model pricing


### PR DESCRIPTION
- Add specific instructions to use docs MCP server for CLI research
- Include detailed CLI query examples for each supported CLI
- Cross-reference documentation research with actual Docker implementations
- Add docs MCP server as a dependency for comprehensive CLI analysis
- Specify CLI research as a success criteria and deliverable

This ensures the assessment task leverages the newly ingested CLI
documentation for informed analysis of current implementation gaps.