### PR TITLE
fix: Update Helm values to use CLI documentation tools

### DIFF
--- a/infra/charts/controller/values.yaml
+++ b/infra/charts/controller/values.yaml
@@ -150,7 +150,7 @@ agents:
       effectively with the broader AI agent team. You bring deep expertise and
       strategic thinking to every challenge.
     tools:
-      remote: ["brave_web_search", "solana_Solana_Expert__Ask_For_Help", "context7_get_library_docs", "rustdocs_query_rust_docs", "agent_docs_add_rust_crate", "agent_docs_birdeye_query", "agent_docs_solana_query", "agent_docs_jupiter_query", "agent_docs_meteora_query", "agent_docs_raydium_query"]
+      remote: ["brave_web_search", "context7_get_library_docs", "rustdocs_query_rust_docs", "agent_docs_codex_query", "agent_docs_cursor_query", "agent_docs_opencode_query", "agent_docs_gemini_query", "agent_docs_grok_query", "agent_docs_qwen_query", "agent_docs_openhands_query"]
 
   cleo:
     name: "Cleo"
@@ -179,7 +179,7 @@ agents:
 
       If any change would alter program semantics or behavior, STOP immediately and create a PR comment explaining why the fix cannot be applied safely.
     tools:
-      remote: ["brave_web_search", "solana_Solana_Expert__Ask_For_Help", "context7_get_library_docs", "rustdocs_query_rust_docs", "agent_docs_add_rust_crate", "agent_docs_birdeye_query", "agent_docs_solana_query", "agent_docs_jupiter_query", "agent_docs_meteora_query", "agent_docs_raydium_query"]
+      remote: ["brave_web_search", "context7_get_library_docs", "rustdocs_query_rust_docs", "agent_docs_codex_query", "agent_docs_cursor_query", "agent_docs_opencode_query", "agent_docs_gemini_query", "agent_docs_grok_query", "agent_docs_qwen_query", "agent_docs_openhands_query"]
 
   tess:
     name: "Tess"
@@ -219,7 +219,7 @@ agents:
 
       **IMPORTANT: After submitting your PR review, your work is complete. Exit immediately.**
     tools:
-      remote: ["brave_web_search", "solana_Solana_Expert__Ask_For_Help", "context7_get_library_docs", "rustdocs_query_rust_docs", "agent_docs_add_rust_crate", "agent_docs_birdeye_query", "agent_docs_solana_query", "agent_docs_jupiter_query", "agent_docs_meteora_query", "agent_docs_raydium_query", "kubernetes_helmInstall", "kubernetes_helmRollback", "kubernetes_getPodMetrics", "kubernetes_getPodsLogs", "kubernetes_describeResource", "kubernetes_listResources", "kubernetes_getEvents", "kubernetes_getNodeMetrics", "kubernetes_helmList", "kubernetes_helmGet", "kubernetes_helmUpgrade", "kubernetes_helmRepoAdd", "kubernetes_helmRepoList", "kubernetes_getResource", "kubernetes_helmUninstall", "kubernetes_createResource"]
+      remote: ["brave_web_search", "context7_get_library_docs", "rustdocs_query_rust_docs", "agent_docs_codex_query", "agent_docs_cursor_query", "agent_docs_opencode_query", "agent_docs_gemini_query", "agent_docs_grok_query", "agent_docs_qwen_query", "agent_docs_openhands_query", "kubernetes_helmInstall", "kubernetes_helmRollback", "kubernetes_getPodMetrics", "kubernetes_getPodsLogs", "kubernetes_describeResource", "kubernetes_listResources", "kubernetes_getEvents", "kubernetes_getNodeMetrics", "kubernetes_helmList", "kubernetes_helmGet", "kubernetes_helmUpgrade", "kubernetes_helmRepoAdd", "kubernetes_helmRepoList", "kubernetes_getResource", "kubernetes_helmUninstall", "kubernetes_createResource"]
 
   blaze:
     name: "Blaze"


### PR DESCRIPTION
Issue: Agent pods were getting old Trader tool configuration
(birdeye_query, solana_query, etc.) instead of CLI tools.

Root cause: Controller reads tool config from Helm values.yaml,
not cto-config.json. Helm chart had stale Trader configuration.

Changes:
- Rex: Updated remote tools to CLI documentation tools
- Cleo: Updated remote tools to CLI documentation tools
- Tess: Updated remote tools to CLI tools + kept Kubernetes tools
- Removed Solana-specific tools (solana_Solana_Expert__Ask_For_Help, agent_docs_add_rust_crate)

New CLI tools:
- agent_docs_codex_query
- agent_docs_cursor_query
- agent_docs_opencode_query
- agent_docs_gemini_query
- agent_docs_grok_query
- agent_docs_qwen_query
- agent_docs_openhands_query

This will allow Rex to perform comprehensive CLI research for
Task 1 analysis as intended.