### PR TITLE
feat(controller): add remediation and QA status to CodeRun and workflow management

### DIFF
--- a/controller/src/crds/coderun.rs
+++ b/controller/src/crds/coderun.rs
@@ -166,6 +166,14 @@ pub struct CodeRunStatus {
     /// Pull request URL if created
     pub pull_request_url: Option<String>,
 
+    /// Latest remediation status label applied to the PR (e.g., needs-fixes, needs-tess, approved)
+    #[serde(rename = "remediationStatus", skip_serializing_if = "Option::is_none")]
+    pub remediation_status: Option<String>,
+
+    /// QA decision captured from Tess (approved, changes_requested, pending)
+    #[serde(rename = "qaStatus", skip_serializing_if = "Option::is_none")]
+    pub qa_status: Option<String>,
+
     /// Current retry attempt (if applicable)
     pub retry_count: Option<u32>,
 

--- a/controller/src/tasks/code/controller.rs
+++ b/controller/src/tasks/code/controller.rs
@@ -415,6 +415,16 @@ async fn handle_workflow_resumption_on_completion(code_run: &CodeRun, ctx: &Cont
         }
     };
 
+    let remediation_status = code_run
+        .status
+        .as_ref()
+        .and_then(|s| s.remediation_status.as_deref());
+
+    let qa_status = code_run
+        .status
+        .as_ref()
+        .and_then(|s| s.qa_status.as_deref());
+
     // Check if PR URL is already available
     if let Some(status) = &code_run.status {
         if let Some(pr_url) = &status.pull_request_url {
@@ -433,6 +443,8 @@ async fn handle_workflow_resumption_on_completion(code_run: &CodeRun, ctx: &Cont
                     &workflow_name,
                     pr_url,
                     pr_number,
+                    remediation_status,
+                    qa_status,
                 )
                 .await
                 {
@@ -518,12 +530,22 @@ async fn handle_no_pr_timeout(
                         return Ok(());
                     }
                 };
+                let remediation_status = updated_code_run
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.remediation_status.as_deref());
+                let qa_status = updated_code_run
+                    .status
+                    .as_ref()
+                    .and_then(|s| s.qa_status.as_deref());
                 if let Err(e) = crate::tasks::workflow::resume_workflow_for_pr(
                     &ctx.client,
                     &ctx.namespace,
                     workflow_name,
                     pr_url,
                     pr_number,
+                    remediation_status,
+                    qa_status,
                 )
                 .await
                 {
@@ -553,12 +575,22 @@ async fn handle_no_pr_timeout(
                 return Ok(());
             }
         };
+        let remediation_status = updated_code_run
+            .status
+            .as_ref()
+            .and_then(|s| s.remediation_status.as_deref());
+        let qa_status = updated_code_run
+            .status
+            .as_ref()
+            .and_then(|s| s.qa_status.as_deref());
         if let Err(e) = crate::tasks::workflow::resume_workflow_for_pr(
             &ctx.client,
             &ctx.namespace,
             workflow_name,
             &pr_url,
             pr_number,
+            remediation_status,
+            qa_status,
         )
         .await
         {

--- a/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-cleo.sh.hbs
@@ -554,6 +554,40 @@ pr_remove_labels() {
   done
 }
 
+update_coderun_status() {
+  local remediation="$1"
+  local qa="$2"
+  local pr_url_value="${3:-$PR_URL}"
+
+  if ! command -v kubectl >/dev/null 2>&1; then
+    return
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "⚠️ jq not available; skipping CodeRun status update"
+    return
+  fi
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  local patch
+  patch=$(jq -n \
+    --arg ts "$timestamp" \
+    --arg pr "$pr_url_value" \
+    --arg rem "$remediation" \
+    --arg qa "$qa" \
+    '{status: ({lastUpdate: $ts}
+        + (if $pr != "" then {pullRequestUrl: $pr} else {} end)
+        + (if $rem != "" then {remediationStatus: $rem} else {} end)
+        + (if $qa != "" then {qaStatus: $qa} else {} end))}')
+
+  if [ -n "$CODERUN_NAME" ] && [ -n "$NAMESPACE" ]; then
+    kubectl patch coderun "$CODERUN_NAME" -n "$NAMESPACE" --type=merge --subresource=status -p "$patch" >/dev/null 2>&1 || \
+      echo "⚠️ Failed to update CodeRun status with remediation context"
+  fi
+}
+
 # Copy client-config.json from task files first
 if [ -f "/task-files/client-config.json" ]; then
   cp /task-files/client-config.json "$CLAUDE_WORK_DIR/client-config.json"
@@ -1185,6 +1219,7 @@ if [ -n "$PR_NUMBER" ] || [ -n "$PR_URL" ]; then
       "$STATUS_LABEL_FAILED" \
       "$STATUS_LABEL_NEEDS_TESTS_LEGACY"
     pr_add_labels "$REPO_SLUG" "$PR_NUMBER" "$PR_URL" "$STATUS_LABEL_NEEDS_TESS"
+    update_coderun_status "$STATUS_LABEL_NEEDS_TESS" "pending" "$PR_URL"
   else
     echo "🏷️ Updating remediation labels: Quality issues detected"
     pr_remove_labels "$REPO_SLUG" "$PR_NUMBER" "$PR_URL" \
@@ -1194,9 +1229,11 @@ if [ -n "$PR_NUMBER" ] || [ -n "$PR_URL" ]; then
       "$STATUS_LABEL_FAILED" \
       "$STATUS_LABEL_NEEDS_TESTS_LEGACY"
     pr_add_labels "$REPO_SLUG" "$PR_NUMBER" "$PR_URL" "$STATUS_LABEL_NEEDS_FIXES"
+    update_coderun_status "$STATUS_LABEL_NEEDS_FIXES" "changes_requested" "$PR_URL"
   fi
 else
   echo "⚠️ No PR reference available, skipping remediation label update"
+  update_coderun_status "$STATUS_LABEL_NEEDS_FIXES" "changes_requested" ""
 fi
 
 # Gracefully stop sidecar (with enhanced debugging and retries)

--- a/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-rex.sh.hbs
@@ -806,6 +806,40 @@ pr_remove_labels() {
   done
 }
 
+update_coderun_status() {
+  local remediation="$1"
+  local qa="$2"
+  local pr_url_value="${3:-$PR_URL}"
+
+  if ! command -v kubectl >/dev/null 2>&1; then
+    return
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "⚠️ jq not available; skipping CodeRun status update"
+    return
+  fi
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  local patch
+  patch=$(jq -n \
+    --arg ts "$timestamp" \
+    --arg pr "$pr_url_value" \
+    --arg rem "$remediation" \
+    --arg qa "$qa" \
+    '{status: ({lastUpdate: $ts}
+        + (if $pr != "" then {pullRequestUrl: $pr} else {} end)
+        + (if $rem != "" then {remediationStatus: $rem} else {} end)
+        + (if $qa != "" then {qaStatus: $qa} else {} end))}')
+
+  if [ -n "$CODERUN_NAME" ] && [ -n "$NAMESPACE" ]; then
+    kubectl patch coderun "$CODERUN_NAME" -n "$NAMESPACE" --type=merge --subresource=status -p "$patch" >/dev/null 2>&1 || \
+      echo "⚠️ Failed to update CodeRun status with remediation context"
+  fi
+}
+
 SRC_OK=false
 WS_OK=false
 if is_valid_cfg "$SOURCE_CFG"; then SRC_OK=true; fi
@@ -1581,29 +1615,8 @@ if [ -n "${GITHUB_TOKEN:-}" ] && command -v gh >/dev/null 2>&1; then
 
     pr_add_labels "$REPO_SLUG" "$PR_NUMBER" "$PR_URL" "$STATUS_LABEL_NEEDS_CLEO"
 
-    # Update CodeRun status with PR URL via Kubernetes API
-    echo "🔄 Updating CodeRun status with PR URL..."
-    if command -v kubectl >/dev/null 2>&1; then
-      # Create a patch to update the CodeRun status
-      PATCH_JSON=$(cat <<EOF
-{
-  "status": {
-    "pullRequestUrl": "$PR_URL",
-    "lastUpdate": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
-  }
-}
-EOF
-)
-
-      # Apply the patch to update CodeRun status
-      if kubectl patch coderun "$CODERUN_NAME" -n "$NAMESPACE" --type=merge --subresource=status -p "$PATCH_JSON" 2>/dev/null; then
-        echo "✅ Updated CodeRun status with PR URL"
-      else
-        echo "⚠️ Failed to update CodeRun status (kubectl patch failed)"
-      fi
-    else
-      echo "⚠️ kubectl not available, cannot update CodeRun status"
-    fi
+    echo "🔄 Recording remediation status (needs-cleo) for CodeRun"
+    update_coderun_status "$STATUS_LABEL_NEEDS_CLEO" "pending" "$PR_URL"
 
     # Apply correlation labels with comprehensive debugging
     echo "🏷️ Adding correlation labels to PR #${PR_NUMBER}..."

--- a/infra/charts/controller/claude-templates/code/container-tess.sh.hbs
+++ b/infra/charts/controller/claude-templates/code/container-tess.sh.hbs
@@ -814,6 +814,40 @@ pr_remove_labels() {
   done
 }
 
+update_coderun_status() {
+  local remediation="$1"
+  local qa="$2"
+  local pr_url_value="${3:-$PR_URL}"
+
+  if ! command -v kubectl >/dev/null 2>&1; then
+    return
+  fi
+
+  if ! command -v jq >/dev/null 2>&1; then
+    echo "⚠️ jq not available; skipping CodeRun status update"
+    return
+  fi
+
+  local timestamp
+  timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+
+  local patch
+  patch=$(jq -n \
+    --arg ts "$timestamp" \
+    --arg pr "$pr_url_value" \
+    --arg rem "$remediation" \
+    --arg qa "$qa" \
+    '{status: ({lastUpdate: $ts}
+        + (if $pr != "" then {pullRequestUrl: $pr} else {} end)
+        + (if $rem != "" then {remediationStatus: $rem} else {} end)
+        + (if $qa != "" then {qaStatus: $qa} else {} end))}')
+
+  if [ -n "$CODERUN_NAME" ] && [ -n "$NAMESPACE" ]; then
+    kubectl patch coderun "$CODERUN_NAME" -n "$NAMESPACE" --type=merge --subresource=status -p "$patch" >/dev/null 2>&1 || \
+      echo "⚠️ Failed to update CodeRun status with remediation context"
+  fi
+}
+
 # Copy client-config.json from task files first
 if [ -f "/task-files/client-config.json" ]; then
   cp /task-files/client-config.json "$CLAUDE_WORK_DIR/client-config.json"
@@ -1951,6 +1985,7 @@ $FAILED_DETAILS
         "$STATUS_LABEL_NEEDS_TESTS_LEGACY"
       pr_add_labels "$REPO_SLUG" "$PR_NUM" "$PR_URL" "$STATUS_LABEL_NEEDS_FIXES"
     fi
+    update_coderun_status "$STATUS_LABEL_NEEDS_FIXES" "changes_requested" "$PR_URL"
   elif [ "$PENDING_CHECKS" -gt 0 ]; then
     echo "⏳ CI checks still pending - posting REQUEST CHANGES review"
     # Get details of pending checks
@@ -1984,6 +2019,7 @@ $PENDING_DETAILS
         "$STATUS_LABEL_NEEDS_TESTS_LEGACY"
       pr_add_labels "$REPO_SLUG" "$PR_NUM" "$PR_URL" "$STATUS_LABEL_NEEDS_TESS"
     fi
+    update_coderun_status "$STATUS_LABEL_NEEDS_TESS" "pending" "$PR_URL"
   elif [ "$SUCCESS_CHECKS" -eq "$TOTAL_CHECKS" ] && [ "$TOTAL_CHECKS" -gt 0 ]; then
     echo "✅ All CI checks passing - posting APPROVE review"
     # Get details of successful checks
@@ -2025,6 +2061,7 @@ $SUCCESS_DETAILS
         "$STATUS_LABEL_NEEDS_TESTS_LEGACY"
       pr_add_labels "$REPO_SLUG" "$PR_NUM" "$PR_URL" "$STATUS_LABEL_APPROVED"
     fi
+    update_coderun_status "$STATUS_LABEL_APPROVED" "approved" "$PR_URL"
   else
     echo "⚠️ Unexpected CI state - posting REQUEST CHANGES review"
     timeout 30 gh pr review "$PR_NUM" --request-changes --body "### 🔴 Required Changes
@@ -2056,6 +2093,7 @@ $SUCCESS_DETAILS
         "$STATUS_LABEL_NEEDS_TESTS_LEGACY"
       pr_add_labels "$REPO_SLUG" "$PR_NUM" "$PR_URL" "$STATUS_LABEL_NEEDS_FIXES"
     fi
+    update_coderun_status "$STATUS_LABEL_NEEDS_FIXES" "changes_requested" "$PR_URL"
   fi
 
 else

--- a/infra/charts/controller/crds/coderun-crd.yaml
+++ b/infra/charts/controller/crds/coderun-crd.yaml
@@ -147,6 +147,12 @@ spec:
               pullRequestUrl:
                 type: string
                 description: "Pull request URL if created"
+              remediationStatus:
+                type: string
+                description: "Latest remediation status label applied to the PR (needs-fixes, needs-tess, approved, etc.)"
+              qaStatus:
+                type: string
+                description: "QA decision recorded by Tess (approved, changes_requested, pending)"
               retryCount:
                 type: integer
                 description: "Current retry attempt (if applicable)"

--- a/sidecar/Cargo.lock
+++ b/sidecar/Cargo.lock
@@ -120,6 +120,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
+name = "errno"
+version = "0.3.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+dependencies = [
+ "libc",
+ "windows-sys",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "37909eebbb50d72f9059c3b6d82c0463f2ff062c9e95845c43a6c9c0355411be"
+
+[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -165,6 +181,18 @@ dependencies = [
  "futures-task",
  "pin-project-lite",
  "pin-utils",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26145e563e54f2cadc477553f1ec5ee650b00862f0a58bcd12cbdc5f0ea2d2f4"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "r-efi",
+ "wasi 0.14.7+wasi-0.2.4",
 ]
 
 [[package]]
@@ -284,6 +312,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
+
+[[package]]
 name = "lock_api"
 version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -342,7 +376,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78bed444cc8a2160f01cbcf811ef18cac863ad68ae8ca62092e8db51d51c761c"
 dependencies = [
  "libc",
- "wasi",
+ "wasi 0.11.1+wasi-snapshot-preview1",
  "windows-sys",
 ]
 
@@ -437,6 +471,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "r-efi"
+version = "5.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -494,6 +534,19 @@ name = "rustc-demangle"
 version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
+
+[[package]]
+name = "rustix"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd15f8a2c5551a84d56efdc1cd049089e409ac19a3072d5037a17fd70719ff3e"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys",
+]
 
 [[package]]
 name = "rustversion"
@@ -581,8 +634,10 @@ name = "sidecar"
 version = "0.1.0"
 dependencies = [
  "axum",
+ "libc",
  "serde",
  "serde_json",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",
@@ -635,6 +690,19 @@ name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
+
+[[package]]
+name = "tempfile"
+version = "3.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d31c77bdf42a745371d260a26ca7163f1e0924b64afa0b688e61b5a9fa02f16"
+dependencies = [
+ "fastrand",
+ "getrandom",
+ "once_cell",
+ "rustix",
+ "windows-sys",
+]
 
 [[package]]
 name = "thread_local"
@@ -785,6 +853,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
+name = "wasi"
+version = "0.14.7+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "883478de20367e224c0090af9cf5f9fa85bed63a95c1abf3afc5c083ebc06e8c"
+dependencies = [
+ "wasip2",
+]
+
+[[package]]
+name = "wasip2"
+version = "1.0.1+wasi-0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0562428422c63773dad2c345a1882263bbf4d65cf3f42e90921f787ef5ad58e7"
+dependencies = [
+ "wit-bindgen",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -878,3 +964,9 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
+
+[[package]]
+name = "wit-bindgen"
+version = "0.46.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f17a85883d4e6d00e8a97c586de764dabcc06133f7f1d55dce5cdc070ad7fe59"

--- a/sidecar/Cargo.toml
+++ b/sidecar/Cargo.toml
@@ -10,5 +10,8 @@ serde_json = "1.0"
 tokio = { version = "1.40", features = ["full"] }
 tracing = "0.1"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+libc = "0.2"
 
+[dev-dependencies]
+tempfile = "3"
 


### PR DESCRIPTION
- Introduced `remediation_status` and `qa_status` fields in `CodeRunStatus` for tracking PR remediation and QA decisions.
- Updated workflow functions to accept and propagate these new statuses during workflow resumption.
- Enhanced the `update_coderun_status` function in shell scripts to include remediation and QA status updates.
- Updated CRD definition to reflect the new fields for better integration and tracking.