### PR TITLE
Add trader app to gitops deployments

### DIFF
--- a/infra/gitops/applications/trader.yaml
+++ b/infra/gitops/applications/trader.yaml
@@ -1,0 +1,101 @@
+---
+# Argo CD Application for Trader Service
+# This enables GitOps deployment of the trader application using the universal Helm chart
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trader
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: trader
+    app.kubernetes.io/part-of: platform
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  # Project configuration
+  project: platform
+
+  # Source configuration
+  source:
+    repoURL: https://github.com/5dlabs/charts
+    targetRevision: main
+    path: universal
+
+    # Helm configuration
+    helm:
+      valueFiles:
+        - values.yaml
+
+      # Override values for GitOps deployment
+      parameters:
+        - name: image.repository
+          value: ghcr.io/5dlabs/trader/paper_trader
+        - name: image.tag
+          value: latest
+        - name: image.pullPolicy
+          value: Always
+
+        # Resource configuration
+        - name: resources.limits.cpu
+          value: 1000m
+        - name: resources.limits.memory
+          value: 1Gi
+        - name: resources.requests.cpu
+          value: 500m
+        - name: resources.requests.memory
+          value: 512Mi
+
+        # Service configuration
+        - name: service.type
+          value: ClusterIP
+        - name: service.port
+          value: "80"
+
+        # Health checks
+        - name: livenessProbe.enabled
+          value: "true"
+        - name: readinessProbe.enabled
+          value: "true"
+
+  # Destination configuration
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: agent-platform
+
+  # Sync policy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - SkipDryRunOnMissingResource=true
+      - Replace=true
+
+    retry:
+      limit: 5
+      backoff:
+        duration: 1s
+        factor: 2
+        maxDuration: 3m
+
+  # Ignore differences for better GitOps experience
+  ignoreDifferences:
+    # Ignore deployment replicas (managed by HPA/manual scaling)
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas
+    # Ignore secret data changes (managed externally)
+    - group: ""
+      kind: Secret
+      jsonPointers:
+        - /data
+
+  # Revision history
+  revisionHistoryLimit: 10


### PR DESCRIPTION
Add Argo CD application for the new `trader` service to enable GitOps deployment using the universal Helm chart.

This application is configured to deploy the `ghcr.io/5dlabs/trader/paper_trader:latest` image to the `agent-platform` namespace, following the established patterns of other applications in `infra/gitops/apps`.

---
<a href="https://cursor.com/background-agent?bcId=bc-6dd528d7-72ca-41ab-b71d-da246859c960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-6dd528d7-72ca-41ab-b71d-da246859c960"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

