### PR TITLE
Add trader app to gitops deployments

### DIFF
--- a/infra/gitops/applications/trader.yaml
+++ b/infra/gitops/applications/trader.yaml
@@ -1,0 +1,123 @@
+---
+# Argo CD Application for Trader
+# This enables GitOps deployment of the trader application
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: trader
+  namespace: argocd
+  labels:
+    app.kubernetes.io/name: trader
+    app.kubernetes.io/part-of: platform
+  finalizers:
+    - resources-finalizer.argocd.argoproj.io
+spec:
+  # Project configuration
+  project: platform
+
+  # Source configuration
+  source:
+    repoURL: https://github.com/5dlabs/charts
+    targetRevision: main
+    path: universal
+
+    # Helm configuration
+    helm:
+      valueFiles:
+        - values.yaml
+
+      # Override values for GitOps deployment
+      parameters:
+        - name: image.repository
+          value: ghcr.io/5dlabs/trader/paper_trader
+        - name: image.tag
+          value: latest
+        - name: image.pullPolicy
+          value: Always
+
+        # Resource configuration
+        - name: resources.limits.cpu
+          value: 1000m
+        - name: resources.limits.memory
+          value: 1Gi
+        - name: resources.requests.cpu
+          value: 500m
+        - name: resources.requests.memory
+          value: 512Mi
+
+        # Service configuration
+        - name: service.port
+          value: "8080"
+        - name: service.type
+          value: ClusterIP
+
+        # Ingress configuration - disabled for trader
+        - name: ingress.enabled
+          value: "false"
+
+        # Replica configuration
+        - name: replicaCount
+          value: "2"
+
+        # Autoscaling configuration
+        - name: autoscaling.enabled
+          value: "true"
+        - name: autoscaling.minReplicas
+          value: "1"
+        - name: autoscaling.maxReplicas
+          value: "10"
+        - name: autoscaling.targetCPUUtilizationPercentage
+          value: "80"
+
+        # Environment variables
+        - name: env[0].name
+          value: "ENVIRONMENT"
+        - name: env[0].value
+          value: "production"
+        - name: env[1].name
+          value: "LOG_LEVEL"
+        - name: env[1].value
+          value: "info"
+
+  # Destination configuration
+  destination:
+    server: https://kubernetes.default.svc
+    namespace: trader
+
+  # Sync policy
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+      allowEmpty: false
+
+    syncOptions:
+      - CreateNamespace=true
+      - PrunePropagationPolicy=foreground
+      - PruneLast=true
+      - SkipDryRunOnMissingResource=true
+      - Replace=true
+
+    retry:
+      limit: 5
+      backoff:
+        duration: 1s
+        factor: 2
+        maxDuration: 3m
+
+  # Ignore differences for better GitOps experience
+  ignoreDifferences:
+    # Ignore deployment replicas (managed by HPA/manual scaling)
+    - group: apps
+      kind: Deployment
+      jsonPointers:
+        - /spec/replicas
+    # Ignore secret data changes (managed externally)
+    - group: ""
+      kind: Secret
+      jsonPointers:
+        - /data
+
+  # Revision history
+  revisionHistoryLimit: 10

--- a/infra/gitops/projects/platform-project.yaml
+++ b/infra/gitops/projects/platform-project.yaml
@@ -21,6 +21,7 @@ spec:
     - 'https://github.com/5dlabs/cto'
     - 'https://github.com/5dlabs/docs'
     - 'https://github.com/5dlabs/toolman'
+    - 'https://github.com/5dlabs/charts'
     - 'https://5dlabs.github.io/cto'
 
     - 'https://github.com/5dlabs/*'

--- a/infra/gitops/projects/platform-project.yaml
+++ b/infra/gitops/projects/platform-project.yaml
@@ -57,6 +57,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: mcp
       server: https://kubernetes.default.svc
+    - namespace: trader
+      server: https://kubernetes.default.svc
     - namespace: arc-systems
       server: https://kubernetes.default.svc
     - namespace: arc-runners


### PR DESCRIPTION
Add ArgoCD application for the new `trader` service to enable GitOps deployment.

---
<a href="https://cursor.com/background-agent?bcId=bc-776fd112-da5a-4f1e-aa22-3d16abd2cc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-776fd112-da5a-4f1e-aa22-3d16abd2cc99"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

