### PR TITLE
chore: add GHCR External Secret for trader namespace

### DIFF
--- a/infra/secret-store/ghcr-external-secrets.yaml
+++ b/infra/secret-store/ghcr-external-secrets.yaml
@@ -190,3 +190,42 @@ spec:
     remoteRef:
       key: github-pat
       property: token
+
+
+---
+# GHCR External Secret for trader namespace
+apiVersion: external-secrets.io/v1beta1
+kind: ExternalSecret
+metadata:
+  name: ghcr-secret
+  namespace: trader
+spec:
+  refreshInterval: 30s
+  secretStoreRef:
+    name: secret-store
+    kind: ClusterSecretStore
+  target:
+    name: ghcr-secret
+    creationPolicy: Owner
+    template:
+      type: kubernetes.io/dockerconfigjson
+      data:
+        .dockerconfigjson: |
+          {
+            "auths": {
+              "ghcr.io": {
+                "username": "{{ .username }}",
+                "password": "{{ .token }}",
+                "auth": "{{ printf "%s:%s" .username .token | b64enc }}"
+              }
+            }
+          }
+  data:
+  - secretKey: username
+    remoteRef:
+      key: github-pat
+      property: username
+  - secretKey: token
+    remoteRef:
+      key: github-pat
+      property: token


### PR DESCRIPTION
- Introduced a new ExternalSecret configuration for the GitHub Container Registry in the `trader` namespace.
- This configuration includes a refresh interval, secret store reference, and target settings for Docker credentials.
- The changes enhance the security of the deployment by managing credentials through Kubernetes secrets.