### PR TITLE
chore: remove obsolete GHCR External Secret for reason namespace

### DIFF
--- a/infra/secret-store/ghcr-external-secrets.yaml
+++ b/infra/secret-store/ghcr-external-secrets.yaml
@@ -151,47 +151,6 @@ spec:
     remoteRef:
       key: github-pat
       property: token
-
-
----
-# GHCR External Secret for reason namespace
-apiVersion: external-secrets.io/v1beta1
-kind: ExternalSecret
-metadata:
-  name: ghcr-secret
-  namespace: reason
-spec:
-  refreshInterval: 30s
-  secretStoreRef:
-    name: secret-store
-    kind: ClusterSecretStore
-  target:
-    name: ghcr-secret
-    creationPolicy: Owner
-    template:
-      type: kubernetes.io/dockerconfigjson
-      data:
-        .dockerconfigjson: |
-          {
-            "auths": {
-              "ghcr.io": {
-                "username": "{{ .username }}",
-                "password": "{{ .token }}",
-                "auth": "{{ printf "%s:%s" .username .token | b64enc }}"
-              }
-            }
-          }
-  data:
-  - secretKey: username
-    remoteRef:
-      key: github-pat
-      property: username
-  - secretKey: token
-    remoteRef:
-      key: github-pat
-      property: token
-
-
 ---
 # GHCR External Secret for trader namespace
 apiVersion: external-secrets.io/v1beta1


### PR DESCRIPTION
- Deleted the ExternalSecret configuration for the GitHub Container Registry in the `reason` namespace.
- This removal helps streamline the GitOps setup by eliminating an outdated configuration that is no longer needed.