### PR TITLE
chore: update liveness and readiness probe configurations in deployment.yaml

### DIFF
--- a/infra/charts/universal-app/templates/deployment.yaml
+++ b/infra/charts/universal-app/templates/deployment.yaml
@@ -67,10 +67,14 @@ spec:
             - name: http
               containerPort: {{ .Values.service.port }}
               protocol: TCP
+          {{- with .Values.livenessProbe }}
           livenessProbe:
-            {{- toYaml .Values.livenessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          {{- with .Values.readinessProbe }}
           readinessProbe:
-            {{- toYaml .Values.readinessProbe | nindent 12 }}
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
           volumeMounts:

--- a/infra/gitops/applications/paper_trader.yaml
+++ b/infra/gitops/applications/paper_trader.yaml
@@ -31,6 +31,8 @@ spec:
       values: |
         imagePullSecrets:
           - name: ghcr-secret
+        livenessProbe: null
+        readinessProbe: null
 
       # Override values for GitOps deployment
       parameters:


### PR DESCRIPTION
- Modified the liveness and readiness probe sections in `deployment.yaml` to use the correct context for values, ensuring proper YAML rendering.
- Set `livenessProbe` and `readinessProbe` to null in `paper_trader.yaml` to disable them by default, allowing for easier customization in deployments.