### PR TITLE
feat: add reasoning effort configuration to AgentDefinition

### DIFF
--- a/controller/src/tasks/code/templates.rs
+++ b/controller/src/tasks/code/templates.rs
@@ -1353,6 +1353,7 @@ mod tests {
                 model: None,
                 max_tokens: None,
                 temperature: None,
+                reasoning_effort: None,
                 tools: Some(agent_tools.clone()),
                 client_config: None,
             },
@@ -1374,6 +1375,7 @@ mod tests {
                 model: None,
                 max_tokens: None,
                 temperature: None,
+                reasoning_effort: None,
                 tools: Some(agent_tools),
                 client_config: Some(serde_json::json!({
                     "remoteTools": ["memory_create_entities", "brave_web_search"],

--- a/infra/charts/controller/agent-templates/code/codex/config.toml.hbs
+++ b/infra/charts/controller/agent-templates/code/codex/config.toml.hbs
@@ -6,6 +6,9 @@ temperature = {{temperature}}
 {{#if max_output_tokens}}
 model_max_output_tokens = {{max_output_tokens}}
 {{/if}}
+{{#if cli_config.settings.reasoningEffort}}
+model_reasoning_effort = "{{cli_config.settings.reasoningEffort}}"
+{{/if}}
 approval_policy = "{{approval_policy}}"
 sandbox_mode = "{{sandbox_mode}}"
 project_doc_max_bytes = {{project_doc_max_bytes}}


### PR DESCRIPTION
## Summary
- extend AgentDefinition with optional reasoning effort
- plumb controller config to pass reasoning setting into CLIConfig and Codex template
- update Codex config template to emit model_reasoning_effort when provided

## Testing
- not run (config serialization change only)