### PR TITLE
fix: include reasoning effort in agent test fixtures

### DIFF
--- a/controller/src/tasks/code/templates.rs
+++ b/controller/src/tasks/code/templates.rs
@@ -1449,6 +1449,7 @@ mod tests {
                 model: None,
                 max_tokens: None,
                 temperature: None,
+                reasoning_effort: None,
                 tools: Some(helm_tools),
                 client_config: None,
             },

--- a/controller/src/tasks/config.rs
+++ b/controller/src/tasks/config.rs
@@ -702,6 +702,7 @@ cleanup:
                 model: Some("gpt-5-codex".to_string()),
                 max_tokens: Some(16000),
                 temperature: Some(0.65),
+                reasoning_effort: None,
                 tools: None,
                 client_config: None,
             },


### PR DESCRIPTION
## Summary
- add explicit `reasoning_effort` assignments to AgentDefinition fixtures in tests
- ensures new optional field compiles and clippy passes

## Testing
- cargo fmt --manifest-path controller/Cargo.toml -- --check
- cargo fmt --manifest-path mcp/Cargo.toml -- --check
- cargo clippy --manifest-path controller/Cargo.toml --all-targets -- -D warnings
- cargo clippy --manifest-path mcp/Cargo.toml --all-targets -- -D warnings
- cargo test --manifest-path controller/Cargo.toml
- cargo test --manifest-path mcp/Cargo.toml