### PR TITLE
chore(secret-store): add CURSOR_API_KEY to external secrets configuration

### DIFF
--- a/infra/secret-store/agent-secrets-external-secrets.yaml
+++ b/infra/secret-store/agent-secrets-external-secrets.yaml
@@ -18,6 +18,10 @@ spec:
     remoteRef:
       key: api-keys
       property: ANTHROPIC_API_KEY
+  - secretKey: CURSOR_API_KEY
+    remoteRef:
+      key: api-keys
+      property: CURSOR_API_KEY
   - secretKey: PERPLEXITY_API_KEY
     remoteRef:
       key: api-keys


### PR DESCRIPTION
Included CURSOR_API_KEY in the agent-secrets-external-secrets.yaml file to enhance the secret management for the agent. This addition ensures that the necessary API key is securely referenced from the external secrets store.