### PR TITLE
fix(infra): exclude test-db directory from deployment in database-instances.yaml

### DIFF
--- a/infra/gitops/applications/database-instances.yaml
+++ b/infra/gitops/applications/database-instances.yaml
@@ -46,8 +46,8 @@ spec:
 
     # Directory configuration - Deploy all database instances
     directory:
-      recurse: true  # Deploy nested database resources (includes test-db subdir)
-      exclude: "{README.md,examples/**}"  # Only exclude docs and examples directory
+      recurse: true
+      exclude: "{README.md,examples/**,test-db/**}"  # test-db managed by its own application
 
   # Destination configuration
   destination:


### PR DESCRIPTION
- Updated the `exclude` field in `database-instances.yaml` to prevent the deployment of the `test-db` directory, which is managed by its own application.
- This change enhances the clarity of the deployment configuration by ensuring that only relevant resources are included.