### PR TITLE
feat(chart): add Cursor API key secret to controller values

### DIFF
--- a/infra/charts/controller/values.yaml
+++ b/infra/charts/controller/values.yaml
@@ -405,6 +405,8 @@ secrets:
       secretKey: "ANTHROPIC_API_KEY"
     codex:
       secretKey: "OPENAI_API_KEY"
+    cursor:
+      secretKey: "CURSOR_API_KEY"
   # Note: GitHub secrets (SSH keys + tokens) are managed externally per agent
   # See infra/scripts/setup-agent-secrets.sh for setup instructions
 


### PR DESCRIPTION
Added a new secret key entry for the Cursor API in the controller's Helm chart values.yaml file. This enhancement supports the integration of Cursor-specific features by allowing the configuration of the Cursor API key within the deployment settings.