### PR TITLE
feat(docker): update cursor-agent installation process in Dockerfile

### DIFF
--- a/infra/images/cursor/Dockerfile
+++ b/infra/images/cursor/Dockerfile
@@ -16,13 +16,17 @@ USER root
 RUN set -eux; \
   curl https://cursor.com/install -fsS | bash; \
   export PATH="$HOME/.local/bin:$PATH"; \
-  if [ -f "$HOME/.local/bin/cursor-agent" ]; then \
-    install -m 0755 "$HOME/.local/bin/cursor-agent" /usr/local/bin/cursor-agent; \
-  fi; \
+  CURSOR_SHARE="$HOME/.local/share/cursor-agent"; \
+  VERSION_DIR="$(cd "$CURSOR_SHARE/versions" && ls -1 | sort | tail -n1)"; \
+  install -d /usr/local/lib/cursor-agent; \
+  cp -r "$CURSOR_SHARE/versions/$VERSION_DIR"/. /usr/local/lib/cursor-agent/; \
+  install -m 0755 "$HOME/.local/bin/cursor-agent" /usr/local/lib/cursor-agent/cursor-agent; \
+  ln -sf ../lib/cursor-agent/cursor-agent /usr/local/bin/cursor-agent; \
+  chown -R 1000:1000 /usr/local/lib/cursor-agent; \
+  rm -rf "$CURSOR_SHARE"; \
   command -v cursor-agent; \
   cursor-agent --help >/dev/null 2>&1 || true
 
 USER node
 
 # Cursor CLI is now available via `cursor-agent`
-


### PR DESCRIPTION
Refactored the Dockerfile for the cursor image to enhance the installation of the cursor-agent. The new process copies the latest version of the cursor-agent to a designated directory and creates a symbolic link for easier access. This change improves the organization of the installation and ensures that the cursor-agent is correctly set up in the container environment.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reworks cursor-agent installation to copy the selected version into `/usr/local/lib/cursor-agent` and symlink `/usr/local/bin/cursor-agent`, with proper ownership and cleanup.
> 
> - **Infra / Docker**:
>   - **Cursor image (`infra/images/cursor/Dockerfile`)**:
>     - Install cursor-agent into `/usr/local/lib/cursor-agent` by copying the latest version from `$HOME/.local/share/cursor-agent/versions`.
>     - Create symlink `/usr/local/bin/cursor-agent` pointing to the lib-managed binary.
>     - Set ownership to UID/GID `1000` and remove the temporary `$HOME/.local/share/cursor-agent` cache.
>     - Retain verification steps: `command -v cursor-agent` and `cursor-agent --help`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 13b0a3c00b11d29c79a3d8046e83a4d326a6579f. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->