### PR TITLE
feat(workflow): add cursor image build step to agents-build workflow

### DIFF
--- a/.github/workflows/agent-templates-sync.yaml
+++ b/.github/workflows/agent-templates-sync.yaml
@@ -1,0 +1,33 @@
+name: Sync Agent Templates ConfigMap
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'infra/charts/controller/agent-templates/**'
+      - 'infra/charts/controller/templates/agent-templates-static.yaml'
+      - 'scripts/generate-templates-configmap.sh'
+      - 'infra/charts/controller/scripts/generate-agent-templates-configmap.sh'
+
+jobs:
+  sync-configmap:
+    runs-on: [k8s-runner]
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Regenerate agent templates ConfigMap
+        run: ./scripts/generate-templates-configmap.sh
+
+      - name: Apply ConfigMap to cluster
+        run: |
+          kubectl apply -n agent-platform -f infra/charts/controller/templates/agent-templates-static.yaml
+
+      - name: Restart controller deployment
+        run: |
+          kubectl rollout restart deployment/controller -n agent-platform
+          kubectl rollout status deployment/controller -n agent-platform --timeout=120s

--- a/.github/workflows/agents-build.yaml
+++ b/.github/workflows/agents-build.yaml
@@ -168,6 +168,11 @@ jobs:
             file: ./infra/images/codex/Dockerfile
             version_type: npm
             version_pkg: "@openai/codex"
+          - id: cursor
+            image: cursor
+            context: ./infra/images/cursor
+            file: ./infra/images/cursor/Dockerfile
+            version_type: dir_hash
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
Included a new build step for the cursor image in the agents-build.yaml workflow. This addition specifies the context and Dockerfile for the cursor image, enhancing the CI/CD pipeline by ensuring the cursor image is built alongside other components.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a workflow to regenerate/apply agent templates ConfigMap and updates agents build matrix to include the cursor image.
> 
> - **CI/CD**:
>   - **New workflow** `/.github/workflows/agent-templates-sync.yaml`:
>     - Triggers on changes to `infra/charts/controller/agent-templates/**`, `templates/agent-templates-static.yaml`, and related scripts.
>     - Regenerates `ConfigMap` via `scripts/generate-templates-configmap.sh`, applies it to `agent-platform`, and restarts `deployment/controller` with rollout wait.
>   - **Agents build** (`.github/workflows/agents-build.yaml`):
>     - Adds `cursor` image to the build matrix with `context` `infra/images/cursor`, Dockerfile path, and `version_type` `dir_hash`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 84d5ae58d4dbcbcfb51065b22e0bcfa25b6af7f9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->