### PR TITLE
chore(rbac): change Role and RoleBinding to ClusterRole and ClusterRo…

### DIFF
--- a/infra/gitops/rbac/arc-runner-agent-platform-access.yaml
+++ b/infra/gitops/rbac/arc-runner-agent-platform-access.yaml
@@ -1,9 +1,8 @@
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: Role
+kind: ClusterRole
 metadata:
   name: arc-runner-agent-platform-writer
-  namespace: agent-platform
 rules:
 - apiGroups: [""]
   resources: ["configmaps"]
@@ -16,13 +15,12 @@ rules:
   verbs: ["get", "list", "watch"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: arc-runner-agent-platform-writer
-  namespace: agent-platform
 roleRef:
   apiGroup: rbac.authorization.k8s.io
-  kind: Role
+  kind: ClusterRole
   name: arc-runner-agent-platform-writer
 subjects:
 - kind: ServiceAccount


### PR DESCRIPTION
…leBinding

Updated the RBAC configuration for the arc-runner-agent to use ClusterRole and ClusterRoleBinding instead of Role and RoleBinding. This change allows for broader permissions across the cluster, enhancing the agent's access capabilities while maintaining the same resource rules.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Scope RBAC to cluster by converting Role/RoleBinding to ClusterRole/ClusterRoleBinding while keeping the same rules.
> 
> - **RBAC**:
>   - Convert `Role` → `ClusterRole` and `RoleBinding` → `ClusterRoleBinding` in `infra/gitops/rbac/arc-runner-agent-platform-access.yaml`.
>   - Remove namespace scoping from `metadata`; update `roleRef.kind` to `ClusterRole`.
>   - Resource rules and subjects unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31fcea87f8fd8d52b832327a0c957bd2a7a3dac7. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->