### PR TITLE
chore(rbac): update GitHub runner RBAC configuration

### DIFF
--- a/infra/gitops/rbac/github-runner-rbac.yaml
+++ b/infra/gitops/rbac/github-runner-rbac.yaml
@@ -8,11 +8,19 @@ rules:
   resources: ["applications"]
   verbs: ["get", "list", "patch", "update"]
 - apiGroups: [""]
-  resources: ["pods", "services", "nodes", "namespaces", "secrets", "configmaps", "serviceaccounts", "persistentvolumeclaims"]
+  resources: ["secrets"]
+  resourceNames: ["argocd-initial-admin-secret"]
+  verbs: ["get", "list"]
+- apiGroups: [""]
+  resources: ["secrets"]
+  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+- apiGroups: [""]
+  resources:
+    ["pods", "services", "nodes", "namespaces", "configmaps", "serviceaccounts", "persistentvolumeclaims"]
   verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
 - apiGroups: ["apps"]
   resources: ["deployments", "replicasets"]
-  verbs: ["get", "list", "watch"]
+  verbs: ["get", "list", "watch", "update", "patch"]
 
 ---
 apiVersion: rbac.authorization.k8s.io/v1

--- a/infra/gitops/rbac/runner-argocd-permissions.yaml
+++ b/infra/gitops/rbac/runner-argocd-permissions.yaml
@@ -1,45 +1,8 @@
 ---
-# ClusterRole for GitHub Actions runners to update ArgoCD applications
-apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: github-runner-argocd-access
-rules:
-- apiGroups: ["argoproj.io"]
-  resources: ["applications"]
-  verbs: ["get", "list", "patch", "update"]
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list"]
-  resourceNames: ["argocd-initial-admin-secret"]
-
-  # Allow runners to manage Helm release secrets in target namespaces
-- apiGroups: [""]
-  resources: ["secrets"]
-  verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
-- apiGroups: [""]
-  resources: ["pods", "services", "deployments"]
-  verbs: ["get", "list", "watch"]
-
-# Allow runners to read cluster node information for diagnostics (e.g., kubectl cluster-info)
-- apiGroups: [""]
-  resources: ["nodes"]
-  verbs: ["get", "list", "watch"]
-
-# Allow runners to manage namespaces for environment setup via kubectl apply
-- apiGroups: [""]
-  resources: ["namespaces"]
-  verbs: ["get", "list", "create", "update", "patch", "delete", "watch"]
-- apiGroups: ["apps"]
-  resources: ["deployments", "replicasets"]
-  verbs: ["get", "list", "watch"]
-
----
-# ClusterRoleBinding to grant permissions to the runner service account
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: github-runner-argocd-access
+  name: arc-runner-argocd-access
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole


### PR DESCRIPTION
Refactored the RBAC configuration for the GitHub runner by consolidating permissions into a single ClusterRole and updating the ClusterRoleBinding name. This change enhances the runner's access to necessary resources while maintaining security and clarity in the permissions structure.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Refactors runner RBAC by splitting secret permissions (including the ArgoCD admin secret), expanding deployment verbs, and renaming a ClusterRoleBinding.
> 
> - **RBAC**:
>   - **`ClusterRole github-runner-argocd-access`** (`infra/gitops/rbac/github-runner-rbac.yaml`):
>     - Add dedicated rule for `secrets` with `resourceNames: ["argocd-initial-admin-secret"]` and `get`, `list`.
>     - Add general `secrets` rule with full CRUD (`get`, `list`, `watch`, `create`, `update`, `patch`, `delete`).
>     - Separate non-secret core resources (`pods`, `services`, `nodes`, `namespaces`, `configmaps`, `serviceaccounts`, `persistentvolumeclaims`) with full CRUD.
>     - Expand `apps` resources (`deployments`, `replicasets`) verbs to include `update`, `patch`.
>   - **`ClusterRoleBinding`** (`infra/gitops/rbac/runner-argocd-permissions.yaml`):
>     - Rename binding to `arc-runner-argocd-access` (still references `github-runner-argocd-access` ClusterRole and same ServiceAccount).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 93d485ab7a554b485e2d9fe6a71bc522afb46f50. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->