### PR TITLE
chore(gitops): add test-db namespace to platform project configuration

### DIFF
--- a/infra/gitops/projects/platform-project.yaml
+++ b/infra/gitops/projects/platform-project.yaml
@@ -70,6 +70,8 @@ spec:
       server: https://kubernetes.default.svc
     - namespace: ngrok-operator
       server: https://kubernetes.default.svc
+    - namespace: test-db
+      server: https://kubernetes.default.svc
     # Removed Jupiter namespace
     - namespace: kube-system
       server: https://kubernetes.default.svc


### PR DESCRIPTION
Updated the platform-project.yaml file to include a new namespace for test-db, enhancing the GitOps configuration for better resource management. This addition ensures that the test database environment is properly integrated into the existing Kubernetes setup.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds `test-db` to Argo CD project `destinations` in `infra/gitops/projects/platform-project.yaml`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d0ab9729ccbbceb56932d2c2a4a035c7ffd1c013. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->