### PR TITLE
feat(templates): enhance CLI rendering settings in code templates

### DIFF
--- a/controller/src/tasks/code/templates.rs
+++ b/controller/src/tasks/code/templates.rs
@@ -201,7 +201,7 @@ impl CodeTemplateGenerator {
             .cloned()
             .unwrap_or_else(|| json!({}));
 
-        let render_settings = Self::build_cli_render_settings(code_run, &cli_config_value);
+        let render_settings = Self::build_cli_render_settings(code_run, cli_config);
         let model = render_settings.model.clone();
         let cli_type = Self::determine_cli_type(code_run).to_string();
 

--- a/controller/src/tasks/code/templates.rs
+++ b/controller/src/tasks/code/templates.rs
@@ -201,6 +201,10 @@ impl CodeTemplateGenerator {
             .cloned()
             .unwrap_or_else(|| json!({}));
 
+        let render_settings = Self::build_cli_render_settings(code_run, &cli_config_value);
+        let model = render_settings.model.clone();
+        let cli_type = Self::determine_cli_type(code_run).to_string();
+
         let workflow_name = extract_workflow_name(code_run)
             .unwrap_or_else(|_| format!("play-task-{}-workflow", code_run.spec.task_id));
 
@@ -220,14 +224,11 @@ impl CodeTemplateGenerator {
                 .unwrap_or(""),
             "github_app": code_run.spec.github_app.as_deref().unwrap_or(""),
             "workflow_name": workflow_name,
+            "model": model.clone(),
+            "cli_type": cli_type,
             "cli": {
-                "type": Self::determine_cli_type(code_run).to_string(),
-                "model": code_run
-                    .spec
-                    .cli_config
-                    .as_ref()
-                    .map(|cfg| cfg.model.as_str())
-                    .unwrap_or(&code_run.spec.model),
+                "type": cli_type,
+                "model": model,
                 "settings": cli_settings,
                 "remote_tools": remote_tools,
             },
@@ -253,6 +254,10 @@ impl CodeTemplateGenerator {
         let template_path = Self::get_cursor_memory_template(code_run);
         let template = Self::load_template(&template_path)?;
 
+        let render_settings = Self::build_cli_render_settings(code_run, cli_config);
+        let model = render_settings.model.clone();
+        let cli_type = Self::determine_cli_type(code_run).to_string();
+
         handlebars
             .register_template_string("cursor_agents", template)
             .map_err(|e| {
@@ -267,12 +272,7 @@ impl CodeTemplateGenerator {
         let context = json!({
             "cli_config": cli_config,
             "github_app": code_run.spec.github_app.as_deref().unwrap_or(""),
-            "model": code_run
-                .spec
-                .cli_config
-                .as_ref()
-                .map(|cfg| cfg.model.as_str())
-                .unwrap_or(&code_run.spec.model),
+            "model": model,
             "task_id": code_run.spec.task_id,
             "service": code_run.spec.service,
             "repository_url": code_run.spec.repository_url,
@@ -285,6 +285,7 @@ impl CodeTemplateGenerator {
                 .unwrap_or(""),
             "working_directory": Self::get_working_directory(code_run),
             "workflow_name": workflow_name,
+            "cli_type": cli_type,
             "toolman": {
                 "tools": remote_tools,
             },


### PR DESCRIPTION
Updated the CodeTemplateGenerator to improve CLI rendering by introducing a dedicated method for building render settings. This change includes the extraction of model and CLI type information, allowing for more flexible and accurate command configurations in the generated templates. The updates ensure that the templates reflect the latest CLI configurations, enhancing the overall functionality of the code generation process.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Cursor container and AGENTS templates now derive `model` via shared render settings and include `cli_type` in their contexts.
> 
> - **Cursor templates (`controller/src/tasks/code/templates.rs`)**:
>   - **Container script**: Use `build_cli_render_settings` to resolve `model`; add `cli_type` and `model` to the render context; update `cli.type`/`cli.model` accordingly.
>   - **AGENTS.md**: Use shared render settings for `model` and include `cli_type` in the context.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 36f94b8228f1536914058f87d2a0a0559a7fcaa0. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->