### PR TITLE
fix(config): standardize naming for context7_get-library-docs tool

### DIFF
--- a/client-config.json
+++ b/client-config.json
@@ -2,7 +2,7 @@
   "localServers": {},
   "remoteTools": [
     "brave_search_brave_web_search",
-    "context7_get_library_docs",
+    "context7_get-library-docs",
     "memory_create_entities",
     "memory_add_observations",
     "memory_read_graph",

--- a/cto-config.json
+++ b/cto-config.json
@@ -59,7 +59,7 @@
       "tools": {
         "remote": [
           "brave_search_brave_web_search",
-          "context7_get_library_docs",
+          "context7_get-library-docs",
           "rustdocs_query_rust_docs",
           "agent_docs_codex_query",
           "agent_docs_cursor_query",
@@ -79,7 +79,7 @@
       "tools": {
         "remote": [
           "brave_search_brave_web_search",
-          "context7_get_library_docs",
+          "context7_get-library-docs",
           "rustdocs_query_rust_docs",
           "agent_docs_codex_query",
           "agent_docs_cursor_query",
@@ -99,7 +99,7 @@
       "tools": {
         "remote": [
           "brave_search_brave_web_search",
-          "context7_get_library_docs",
+          "context7_get-library-docs",
           "rustdocs_query_rust_docs",
           "agent_docs_codex_query",
           "agent_docs_cursor_query",
@@ -119,7 +119,7 @@
       "tools": {
         "remote": [
           "brave_search_brave_web_search",
-          "context7_get_library_docs",
+          "context7_get-library-docs",
           "rustdocs_query_rust_docs",
           "agent_docs_codex_query",
           "agent_docs_cursor_query",
@@ -139,7 +139,7 @@
       "tools": {
         "remote": [
           "brave_search_brave_web_search",
-          "context7_get_library_docs",
+          "context7_get-library-docs",
           "agent_docs_codex_query",
           "agent_docs_cursor_query",
           "agent_docs_opencode_query",
@@ -158,7 +158,7 @@
       "tools": {
         "remote": [
           "brave_search_brave_web_search",
-          "context7_get_library_docs"
+          "context7_get-library-docs"
           "rustdocs_query_rust_docs",
           "agent_docs_codex_query",
           "agent_docs_cursor_query",

--- a/infra/charts/controller/values.yaml
+++ b/infra/charts/controller/values.yaml
@@ -132,7 +132,7 @@ agents:
       effectively with the broader AI agent team. You bring deep expertise and
       strategic thinking to every challenge.
     tools:
-      remote: ["brave_search_brave_web_search", "context7_get_library_docs", "rustdocs_query_rust_docs", "agent_docs_codex_query", "agent_docs_cursor_query", "agent_docs_opencode_query", "agent_docs_gemini_query", "agent_docs_grok_query", "agent_docs_qwen_query", "agent_docs_openhands_query"]
+      remote: ["brave_search_brave_web_search", "context7_get-library-docs", "rustdocs_query_rust_docs", "agent_docs_codex_query", "agent_docs_cursor_query", "agent_docs_opencode_query", "agent_docs_gemini_query", "agent_docs_grok_query", "agent_docs_qwen_query", "agent_docs_openhands_query"]
 
   cleo:
     name: "Cleo"
@@ -165,7 +165,7 @@ agents:
 
       If any change would alter program semantics or behavior, STOP immediately and create a PR comment explaining why the fix cannot be applied safely.
     tools:
-      remote: ["brave_search_brave_web_search", "context7_get_library_docs", "rustdocs_query_rust_docs", "agent_docs_codex_query", "agent_docs_cursor_query", "agent_docs_opencode_query", "agent_docs_gemini_query", "agent_docs_grok_query", "agent_docs_qwen_query", "agent_docs_openhands_query"]
+      remote: ["brave_search_brave_web_search", "context7_get-library-docs", "rustdocs_query_rust_docs", "agent_docs_codex_query", "agent_docs_cursor_query", "agent_docs_opencode_query", "agent_docs_gemini_query", "agent_docs_grok_query", "agent_docs_qwen_query", "agent_docs_openhands_query"]
 
   tess:
     name: "Tess"
@@ -209,7 +209,7 @@ agents:
 
       **IMPORTANT: After submitting your PR review, your work is complete. Exit immediately.**
     tools:
-      remote: ["brave_search_brave_web_search", "context7_get_library_docs", "rustdocs_query_rust_docs", "agent_docs_codex_query", "agent_docs_cursor_query", "agent_docs_opencode_query", "agent_docs_gemini_query", "agent_docs_grok_query", "agent_docs_qwen_query", "agent_docs_openhands_query", "kubernetes_helmInstall", "kubernetes_helmRollback", "kubernetes_getPodMetrics", "kubernetes_getPodsLogs", "kubernetes_describeResource", "kubernetes_listResources", "kubernetes_getEvents", "kubernetes_getNodeMetrics", "kubernetes_helmList", "kubernetes_helmGet", "kubernetes_helmUpgrade", "kubernetes_helmRepoAdd", "kubernetes_helmRepoList", "kubernetes_getResource", "kubernetes_helmUninstall", "kubernetes_createResource"]
+      remote: ["brave_search_brave_web_search", "context7_get-library-docs", "rustdocs_query_rust_docs", "agent_docs_codex_query", "agent_docs_cursor_query", "agent_docs_opencode_query", "agent_docs_gemini_query", "agent_docs_grok_query", "agent_docs_qwen_query", "agent_docs_openhands_query", "kubernetes_helmInstall", "kubernetes_helmRollback", "kubernetes_getPodMetrics", "kubernetes_getPodsLogs", "kubernetes_describeResource", "kubernetes_listResources", "kubernetes_getEvents", "kubernetes_getNodeMetrics", "kubernetes_helmList", "kubernetes_helmGet", "kubernetes_helmUpgrade", "kubernetes_helmRepoAdd", "kubernetes_helmRepoList", "kubernetes_getResource", "kubernetes_helmUninstall", "kubernetes_createResource"]
 
   blaze:
     name: "Blaze"


### PR DESCRIPTION
Updated the naming convention for the "context7_get_library_docs" tool to "context7_get-library-docs" across multiple configuration files to ensure consistency and prevent potential identification issues.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Renames `context7_get_library_docs` to `context7_get-library-docs` across client, CTO agent configs, and Helm chart values to keep tool identifiers consistent.
> 
> - **Config standardization**:
>   - Replace `context7_get_library_docs` with `context7_get-library-docs` in `client-config.json`.
>   - Update CTO agent tool lists in `cto-config.json` (`morgan`, `rex`, `cleo`, `tess`, `blaze`, `cipher`).
>   - Update Helm chart `infra/charts/controller/values.yaml` tool lists for agents (`rex`, `cleo`, `tess`).
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 629645f2308cb211e17021e35723079329fbaa11. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->