### PR TITLE
fix(config): update default Docker-in-Docker setting for CodeRun

### DIFF
--- a/controller/src/crds/coderun.rs
+++ b/controller/src/crds/coderun.rs
@@ -39,6 +39,10 @@ fn default_overwrite_memory() -> bool {
     false
 }
 
+fn default_enable_docker() -> Option<bool> {
+    Some(true)
+}
+
 /// CLI-specific configuration
 #[derive(Deserialize, Serialize, Clone, Debug, JsonSchema)]
 pub struct CLIConfig {
@@ -131,8 +135,8 @@ pub struct CodeRunSpec {
     #[serde(default, rename = "envFromSecrets")]
     pub env_from_secrets: Vec<SecretEnvVar>,
 
-    /// Whether to enable Docker-in-Docker support for this CodeRun (defaults to false)
-    #[serde(default, rename = "enableDocker")]
+    /// Whether to enable Docker-in-Docker support for this CodeRun (defaults to true)
+    #[serde(default = "default_enable_docker", rename = "enableDocker")]
     pub enable_docker: Option<bool>,
 
     /// Base64-encoded YAML containing task requirements (secrets and environment variables)

--- a/infra/charts/controller/crds/coderun-crd.yaml
+++ b/infra/charts/controller/crds/coderun-crd.yaml
@@ -121,8 +121,8 @@ spec:
                 description: "Environment variables from secrets"
               enableDocker:
                 type: boolean
-                description: "Whether to enable Docker-in-Docker support for this CodeRun (defaults to false)"
-                default: false
+                description: "Whether to enable Docker-in-Docker support for this CodeRun (defaults to true)"
+                default: true
               taskRequirements:
                 type: string
                 description: "Base64-encoded YAML containing task requirements (secrets and environment variables)"


### PR DESCRIPTION
Changed the default value for the `enableDocker` field in the CodeRun configuration from false to true, ensuring that Docker-in-Docker support is enabled by default. Updated related documentation in the CRD YAML file to reflect this change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Sets `enableDocker` default to true in CodeRun spec and CRD, updating implementation and schema docs.
> 
> - **CRD defaults**:
>   - `controller/src/crds/coderun.rs`:
>     - Add `default_enable_docker()` returning `Some(true)` and set `serde(default = "default_enable_docker")` for `spec.enable_docker`; update field description to default to true.
>   - `infra/charts/controller/crds/coderun-crd.yaml`:
>     - Change `spec.properties.enableDocker.default` to `true` and update description to reflect default true.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 548ddcc95cef2d261f42d460cc546216dae20f37. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->