### PR TITLE
fix(factory): add permissions for factory-cli temp directories

### DIFF
--- a/infra/images/factory/Dockerfile
+++ b/infra/images/factory/Dockerfile
@@ -9,9 +9,10 @@ ENV DEVCONTAINER=true
 
 USER root
 
-# Ensure workspace and Factory home exist for the non-root user
-RUN mkdir -p /workspace /home/${USERNAME}/.factory && \
-    chown -R 1000:1000 /workspace /home/${USERNAME}/.factory
+# Ensure workspace, Factory home, and temp directories exist for the non-root user
+RUN mkdir -p /workspace /home/${USERNAME}/.factory /tmp/factory-cli-images && \
+    chown -R 1000:1000 /workspace /home/${USERNAME}/.factory /tmp/factory-cli-images && \
+    chmod 775 /tmp/factory-cli-images
 
 WORKDIR /workspace
 


### PR DESCRIPTION
Factory CLI requires write access to /tmp/factory-cli-images/ for image caching.
Updated Dockerfile to create this directory with proper ownership (1000:1000)
and permissions (775) before switching to non-root user.

This resolves EACCES permission denied errors when droid attempts to create
temporary directories during execution.