### PR TITLE
fix(workflow): update play workflow template for testing stage transitions

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -333,8 +333,6 @@ spec:
                   value: "{{`{{steps.implementation.outputs.parameters.pr-url}}`}}"
                 - name: pr-number
                   value: "{{`{{steps.implementation.outputs.parameters.pr-number}}`}}"
-                - name: qa-ready
-                  value: "true"
         - - name: update-to-waiting-testing-complete
             template: update-workflow-stage
             arguments:
@@ -371,6 +369,8 @@ spec:
                   value: "{{`{{steps.implementation.outputs.parameters.pr-url}}`}}"
                 - name: pr-number
                   value: "{{`{{steps.implementation.outputs.parameters.pr-number}}`}}"
+                - name: testing-complete
+                  value: "true"
         - - name: update-to-waiting-ready-for-qa
             template: update-workflow-stage
             arguments:

--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -263,7 +263,7 @@ spec:
                 - name: stage
                   value: "{{`{{inputs.parameters.stage}}`}}"
 
-    # Run a full remediation iteration (Rex → Cleo → Tess) with automatic retries
+    # Run a full remediation iteration (Rex → Tess → Cleo) with automatic retries
     - name: remediation-iteration
       outputs:
         parameters:
@@ -313,42 +313,6 @@ spec:
                   value: "pr-created"
                 - name: stage-name
                   value: "waiting-pr-created"
-        - - name: quality-work
-            template: agent-coderun
-            arguments:
-              parameters:
-                - name: github-app
-                  value: "{{`{{workflow.parameters.quality-agent}}`}}"
-                - name: task-id
-                  value: "{{`{{workflow.parameters.task-id}}`}}"
-                - name: stage
-                  value: "quality"
-                - name: cli-type
-                  value: "{{`{{workflow.parameters.quality-cli}}`}}"
-                - name: model
-                  value: "{{`{{workflow.parameters.quality-model}}`}}"
-                - name: tools-config
-                  value: "{{`{{workflow.parameters.quality-tools}}`}}"
-                - name: pr-url
-                  value: "{{`{{steps.implementation.outputs.parameters.pr-url}}`}}"
-                - name: pr-number
-                  value: "{{`{{steps.implementation.outputs.parameters.pr-number}}`}}"
-        - - name: update-to-waiting-qa
-            template: update-workflow-stage
-            arguments:
-              parameters:
-                - name: new-stage
-                  value: "waiting-ready-for-qa"
-                - name: verify-update
-                  value: "true"
-        - - name: wait-for-ready-for-qa
-            template: suspend-for-event
-            arguments:
-              parameters:
-                - name: event-type
-                  value: "ready-for-qa"
-                - name: stage-name
-                  value: "waiting-ready-for-qa"
         - - name: testing-work
             template: agent-coderun
             arguments:
@@ -371,6 +335,58 @@ spec:
                   value: "{{`{{steps.implementation.outputs.parameters.pr-number}}`}}"
                 - name: qa-ready
                   value: "true"
+        - - name: update-to-waiting-testing-complete
+            template: update-workflow-stage
+            arguments:
+              parameters:
+                - name: new-stage
+                  value: "waiting-testing-complete"
+                - name: verify-update
+                  value: "true"
+        - - name: wait-for-testing-complete
+            template: suspend-for-event
+            arguments:
+              parameters:
+                - name: event-type
+                  value: "testing-complete"
+                - name: stage-name
+                  value: "waiting-testing-complete"
+        - - name: quality-work
+            template: agent-coderun
+            arguments:
+              parameters:
+                - name: github-app
+                  value: "{{`{{workflow.parameters.quality-agent}}`}}"
+                - name: task-id
+                  value: "{{`{{workflow.parameters.task-id}}`}}"
+                - name: stage
+                  value: "quality"
+                - name: cli-type
+                  value: "{{`{{workflow.parameters.quality-cli}}`}}"
+                - name: model
+                  value: "{{`{{workflow.parameters.quality-model}}`}}"
+                - name: tools-config
+                  value: "{{`{{workflow.parameters.quality-tools}}`}}"
+                - name: pr-url
+                  value: "{{`{{steps.implementation.outputs.parameters.pr-url}}`}}"
+                - name: pr-number
+                  value: "{{`{{steps.implementation.outputs.parameters.pr-number}}`}}"
+        - - name: update-to-waiting-ready-for-qa
+            template: update-workflow-stage
+            arguments:
+              parameters:
+                - name: new-stage
+                  value: "waiting-ready-for-qa"
+                - name: verify-update
+                  value: "true"
+        - - name: wait-for-ready-for-qa
+            template: suspend-for-event
+            arguments:
+              parameters:
+                - name: event-type
+                  value: "ready-for-qa"
+                - name: stage-name
+                  value: "waiting-ready-for-qa"
         - - name: evaluate-remediation
             template: assess-remediation-outcome
             arguments:
@@ -932,12 +948,15 @@ spec:
               return 0
             fi
 
-            # Define valid transitions
+            # Define valid transitions (Rex → Tess → Cleo flow)
             case $current_stage in
               "pending")
                 [[ $new_stage == "waiting-pr-created" ]] && return 0
                 ;;
               "waiting-pr-created")
+                [[ $new_stage == "waiting-testing-complete" ]] && return 0
+                ;;
+              "waiting-testing-complete")
                 [[ $new_stage == "waiting-ready-for-qa" ]] && return 0
                 ;;
               "waiting-ready-for-qa")

--- a/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
@@ -27,7 +27,23 @@ spec:
             type: string
             value: ["opened"]
 
-    # Ready-for-QA Label Added - Resume workflows waiting for this
+    # Testing Complete Label Added - Resume workflows waiting for this (Tess adds this)
+    - name: testing-complete-event
+      eventSourceName: github
+      eventName: org
+      filters:
+        data:
+          - path: headers.X-Github-Event
+            type: string
+            value: ["pull_request"]
+          - path: body.action
+            type: string
+            value: ["labeled"]
+          - path: body.label.name
+            type: string
+            value: ["testing-complete"]
+
+    # Ready-for-QA Label Added - Resume workflows waiting for this (Cleo adds this)
     - name: ready-for-qa-event
       eventSourceName: github
       eventName: org
@@ -251,6 +267,103 @@ spec:
                           2>/dev/null || echo "")
 
                         if [ "$CURRENT_STAGE" = "waiting-pr-merged" ]; then
+                          echo "Found workflow at correct stage, resuming..."
+
+                          # Resume the workflow
+                          kubectl patch workflow $WORKFLOW_NAME \
+                            -n agent-platform \
+                            --type='merge' \
+                            -p '{"spec":{"suspend":false}}'
+
+                          echo "✅ Workflow resumed successfully"
+                        else
+                          echo "Workflow not at expected stage (current: $CURRENT_STAGE)"
+                          echo "Skipping resume to prevent incorrect stage progression"
+                        fi
+      retryStrategy:
+        steps: 3
+        duration: "10s"
+        factor: 2
+
+    # Resume workflows at waiting-testing-complete stage
+    - template:
+        name: resume-waiting-testing-complete
+        conditions: "testing-complete-event"
+        k8s:
+          operation: create
+          source:
+            resource:
+              apiVersion: argoproj.io/v1alpha1
+              kind: Workflow
+              metadata:
+                generateName: stage-resume-testing-complete-
+                namespace: agent-platform
+                labels:
+                  type: stage-resume
+                  target-stage: waiting-testing-complete
+              spec:
+                entrypoint: resume-workflow
+                serviceAccountName: argo-workflow
+                templates:
+                  - name: resume-workflow
+                    script:
+                      image: alpine/k8s:1.31.0
+                      command: [bash]
+                      source: |
+                        #!/bin/bash
+                        set -e
+
+                        # Ensure jq is available
+                        if ! command -v jq >/dev/null 2>&1; then
+                          if command -v apk >/dev/null 2>&1; then
+                            apk add --no-cache jq
+                          fi
+                        fi
+
+                        echo "=== Stage-Aware Workflow Resume ==="
+                        echo "Target Stage: waiting-testing-complete"
+                        echo "Label Added: {{ .Input.body.label.name }}"
+                        echo "Added By: {{ .Input.body.sender.login }}"
+
+                        # Verify label was added by Tess
+                        SENDER="{{ .Input.body.sender.login }}"
+                        if [[ ! "$SENDER" =~ 5DLabs-Tess ]]; then
+                          echo "Label not added by Tess, ignoring..."
+                          exit 0
+                        fi
+
+                        # Extract task ID from PR labels
+                        TASK_LABELS_JSON='{{ .Input.body.pull_request.labels | toJson }}'
+                        TASK_ID=$(echo "$TASK_LABELS_JSON" \
+                          | jq -r '.[] | (.name // "") | ascii_downcase | capture("task-(?<id>[0-9]+)") | .id' \
+                          | head -1)
+
+                        if [ -z "$TASK_ID" ]; then
+                          echo "ERROR: No task-* label found on PR"
+                          exit 1
+                        fi
+
+                        echo "Task ID: $TASK_ID"
+
+                        # Find workflow by labels
+                        WORKFLOW_NAME=$(kubectl get workflows -n agent-platform \
+                          -l task-id=$TASK_ID,workflow-type=play-orchestration \
+                          -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+                        if [ -z "$WORKFLOW_NAME" ]; then
+                          echo "ERROR: No workflow found for task-id=$TASK_ID"
+                          exit 1
+                        fi
+
+                        echo "Found workflow: $WORKFLOW_NAME"
+
+                        # Check if workflow is at correct stage
+                        CURRENT_STAGE=$(kubectl get workflow $WORKFLOW_NAME \
+                          -n agent-platform \
+                          -o jsonpath='{.metadata.labels.current-stage}' \
+                          2>/dev/null || echo "")
+
+                        if [ "$CURRENT_STAGE" = "waiting-testing-complete" ]; then
                           echo "Found workflow at correct stage, resuming..."
 
                           # Resume the workflow


### PR DESCRIPTION
This commit modifies the play workflow template to correctly reflect the transition stages for testing and quality assurance. The changes include renaming parameters and updating comments to clarify the workflow's logic, ensuring that the workflow accurately resumes at the appropriate stages based on GitHub events.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Reorders remediation to run testing before QA, adds a new waiting-testing-complete stage with resume sensor on testing-complete label, and updates stage transitions/params accordingly.
> 
> - **Workflow Orchestration (`infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml`)**:
>   - **Flow order**: Change remediation sequence from `Rex → Cleo → Tess` to `Rex → Tess → Cleo`.
>   - **New stage**: Introduce `waiting-testing-complete` between `waiting-pr-created` and `waiting-ready-for-qa`.
>   - **Tasks**:
>     - Replace initial `quality-work` with `testing-work` using `testing-*` params and stage `testing`.
>     - Add `update-to-waiting-testing-complete` and `wait-for-testing-complete` suspend.
>     - Move `quality-work` after testing with `quality-*` params and stage `quality`.
>     - Add transition to `waiting-ready-for-qa` and corresponding wait.
>   - **Validation**: Update `validate_stage_transition` to allow `waiting-pr-created → waiting-testing-complete → waiting-ready-for-qa`.
>   - **Comments/labels**: Update comments to reflect `Rex → Tess → Cleo`; add `testing-complete` flag output.
> - **GitHub Sensor (`infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml`)**:
>   - **New event**: `testing-complete-event` for PR label `testing-complete` (by Tess).
>   - **New resume trigger**: `resume-waiting-testing-complete` to unsuspend workflows at `waiting-testing-complete`.
>   - **Clarifications**: Notes that `ready-for-qa` is added by Cleo; retains existing resume triggers for other stages.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dd68e5108885876c59614eedfe0eb6f539725448. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->