### PR TITLE
feat(gitops): enhance workflow resumption with Argo CLI integration

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -122,12 +122,91 @@ spec:
                               --type='merge' -p "$PATCH_JSON"
                           fi
 
-                          # Resume the workflow
-                          echo "Resuming workflow $WORKFLOW_NAME"
-                          kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
-                            --type='merge' -p '{"spec":{"suspend":false}}'
+                        ensure_argo_cli() {
+                          if command -v argo >/dev/null 2>&1; then
+                            ARGO_BIN=$(command -v argo)
+                            return 0
+                          fi
 
-                          echo "✅ Workflow resumed successfully"
+                          ARGO_VERSION="${ARGO_VERSION:-v3.7.1}"
+                          ARGO_BIN="/tmp/argo"
+
+                          if [ ! -x "$ARGO_BIN" ]; then
+                            echo "Downloading argo CLI ($ARGO_VERSION)..."
+                            if command -v wget >/dev/null 2>&1; then
+                              wget -qO "$ARGO_BIN" "https://github.com/argoproj/argo-workflows/releases/download/$ARGO_VERSION/argo-linux-amd64"
+                            elif command -v curl >/dev/null 2>&1; then
+                              curl -sSL -o "$ARGO_BIN" "https://github.com/argoproj/argo-workflows/releases/download/$ARGO_VERSION/argo-linux-amd64"
+                            else
+                              echo "Neither wget nor curl is available"
+                              return 1
+                            fi
+                            chmod +x "$ARGO_BIN"
+                          fi
+                        }
+
+                        build_kubeconfig() {
+                          KUBECONFIG_PATH="/tmp/argo-kubeconfig"
+                          if [ -f "$KUBECONFIG_PATH" ]; then
+                            echo "$KUBECONFIG_PATH"
+                            return 0
+                          fi
+
+                          CA_CERT="/var/run/secrets/kubernetes.io/serviceaccount/ca.crt"
+                          TOKEN_FILE="/var/run/secrets/kubernetes.io/serviceaccount/token"
+
+                          if [ ! -f "$TOKEN_FILE" ]; then
+                            echo "Service account token not found"
+                            return 1
+                          fi
+
+                          SERVER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
+                          TOKEN=$(cat "$TOKEN_FILE")
+
+                          cat <<EOF > "$KUBECONFIG_PATH"
+apiVersion: v1
+kind: Config
+clusters:
+- cluster:
+    certificate-authority: ${CA_CERT}
+    server: ${SERVER}
+  name: in-cluster
+contexts:
+- context:
+    cluster: in-cluster
+    namespace: agent-platform
+    user: sensor-sa
+  name: in-cluster
+current-context: in-cluster
+users:
+- name: sensor-sa
+  user:
+    token: ${TOKEN}
+EOF
+
+                          echo "$KUBECONFIG_PATH"
+                        }
+
+                        resume_workflow() {
+                          ensure_argo_cli || return 1
+                          KUBECONFIG_PATH=$(build_kubeconfig) || return 1
+
+                          # Resume all suspended nodes within the workflow
+                          if "$ARGO_BIN" --auth-mode kubeconfig --kubeconfig "$KUBECONFIG_PATH" \
+                            -n agent-platform resume "$WORKFLOW_NAME" >/tmp/argo-resume.log 2>&1; then
+                            echo "✅ Workflow resumed successfully"
+                          else
+                            echo "⚠️ Failed to resume via argo CLI; output:"
+                            cat /tmp/argo-resume.log
+                            return 1
+                          fi
+                        }
+
+                        echo "Resuming workflow $WORKFLOW_NAME"
+                        if ! resume_workflow; then
+                          echo "⚠️ Resume attempt failed for $WORKFLOW_NAME"
+                          continue
+                        fi
                         done
 
                         echo "Finished processing waiting workflows"

--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -70,58 +70,6 @@ spec:
                           exit 0
                         fi
 
-                        # Process each waiting workflow
-                        for WORKFLOW_NAME in $WAITING_WORKFLOWS; do
-                          echo "Processing workflow: $WORKFLOW_NAME"
-
-                          # Get task ID from workflow
-                          TASK_ID=$(kubectl get workflow $WORKFLOW_NAME -n agent-platform \
-                            -o jsonpath='{.metadata.labels.task-id}')
-
-                          if [ -z "$TASK_ID" ]; then
-                            echo "No task ID found for workflow, skipping"
-                            continue
-                          fi
-
-                          echo "Task ID: $TASK_ID"
-
-                          # Check if there's a recent succeeded implementation CodeRun for this task
-                          CODERUN=$(kubectl get coderun -n agent-platform \
-                            -l task-id=$TASK_ID,workflow-stage=implementation \
-                            --field-selector=status.phase=Succeeded \
-                            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
-
-                          if [ -z "$CODERUN" ]; then
-                            echo "No succeeded implementation CodeRun for task $TASK_ID, skipping"
-                            continue
-                          fi
-
-                          echo "Found CodeRun: $CODERUN"
-
-                          # Get PR URL from the CodeRun status
-                          PR_URL=$(kubectl get coderun $CODERUN -n agent-platform \
-                            -o jsonpath='{.status.pullRequestUrl}' 2>/dev/null || echo "")
-
-                          if [ -z "$PR_URL" ]; then
-                            echo "No PR URL in CodeRun status, skipping"
-                            continue
-                          fi
-
-                          # Extract PR number from URL
-                          PR_NUMBER=$(echo "$PR_URL" | sed 's/.*\/pull\///' | sed 's/[^0-9].*//')
-
-                          echo "PR URL: $PR_URL"
-                          echo "PR Number: $PR_NUMBER"
-
-                          # Update workflow parameters with PR info
-                          if [ -n "$PR_NUMBER" ] && [ -n "$PR_URL" ]; then
-                            PATCH_JSON="{\"spec\":{\"arguments\":{\"parameters\":["
-                            PATCH_JSON="${PATCH_JSON}{\"name\":\"pr-url\",\"value\":\"$PR_URL\"},"
-                            PATCH_JSON="${PATCH_JSON}{\"name\":\"pr-number\",\"value\":\"$PR_NUMBER\"}]}}}"
-                            kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
-                              --type='merge' -p "$PATCH_JSON"
-                          fi
-
                         ensure_argo_cli() {
                           if command -v argo >/dev/null 2>&1; then
                             ARGO_BIN=$(command -v argo)
@@ -191,7 +139,6 @@ EOF
                           ensure_argo_cli || return 1
                           KUBECONFIG_PATH=$(build_kubeconfig) || return 1
 
-                          # Resume all suspended nodes within the workflow
                           if "$ARGO_BIN" --auth-mode kubeconfig --kubeconfig "$KUBECONFIG_PATH" \
                             -n agent-platform resume "$WORKFLOW_NAME" >/tmp/argo-resume.log 2>&1; then
                             echo "✅ Workflow resumed successfully"
@@ -201,6 +148,58 @@ EOF
                             return 1
                           fi
                         }
+
+                        # Process each waiting workflow
+                        for WORKFLOW_NAME in $WAITING_WORKFLOWS; do
+                          echo "Processing workflow: $WORKFLOW_NAME"
+
+                          # Get task ID from workflow
+                          TASK_ID=$(kubectl get workflow $WORKFLOW_NAME -n agent-platform \
+                            -o jsonpath='{.metadata.labels.task-id}')
+
+                          if [ -z "$TASK_ID" ]; then
+                            echo "No task ID found for workflow, skipping"
+                            continue
+                          fi
+
+                          echo "Task ID: $TASK_ID"
+
+                          # Check if there's a recent succeeded implementation CodeRun for this task
+                          CODERUN=$(kubectl get coderun -n agent-platform \
+                            -l task-id=$TASK_ID,workflow-stage=implementation \
+                            --field-selector=status.phase=Succeeded \
+                            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+
+                          if [ -z "$CODERUN" ]; then
+                            echo "No succeeded implementation CodeRun for task $TASK_ID, skipping"
+                            continue
+                          fi
+
+                          echo "Found CodeRun: $CODERUN"
+
+                          # Get PR URL from the CodeRun status
+                          PR_URL=$(kubectl get coderun $CODERUN -n agent-platform \
+                            -o jsonpath='{.status.pullRequestUrl}' 2>/dev/null || echo "")
+
+                          if [ -z "$PR_URL" ]; then
+                            echo "No PR URL in CodeRun status, skipping"
+                            continue
+                          fi
+
+                          # Extract PR number from URL
+                          PR_NUMBER=$(echo "$PR_URL" | sed 's/.*\/pull\///' | sed 's/[^0-9].*//')
+
+                          echo "PR URL: $PR_URL"
+                          echo "PR Number: $PR_NUMBER"
+
+                          # Update workflow parameters with PR info
+                          if [ -n "$PR_NUMBER" ] && [ -n "$PR_URL" ]; then
+                            PATCH_JSON="{\"spec\":{\"arguments\":{\"parameters\":["
+                            PATCH_JSON="${PATCH_JSON}{\"name\":\"pr-url\",\"value\":\"$PR_URL\"},"
+                            PATCH_JSON="${PATCH_JSON}{\"name\":\"pr-number\",\"value\":\"$PR_NUMBER\"}]}}}"
+                            kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
+                              --type='merge' -p "$PATCH_JSON"
+                          fi
 
                         echo "Resuming workflow $WORKFLOW_NAME"
                         if ! resume_workflow; then

--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -111,26 +111,26 @@ spec:
                           SERVER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
                           TOKEN=$(cat "$TOKEN_FILE")
 
-                          cat <<EOF > "$KUBECONFIG_PATH"
-apiVersion: v1
-kind: Config
-clusters:
-- cluster:
-    certificate-authority: ${CA_CERT}
-    server: ${SERVER}
-  name: in-cluster
-contexts:
-- context:
-    cluster: in-cluster
-    namespace: agent-platform
-    user: sensor-sa
-  name: in-cluster
-current-context: in-cluster
-users:
-- name: sensor-sa
-  user:
-    token: ${TOKEN}
-EOF
+                          cat <<EOF | sed 's/^ \{26\}//' > "$KUBECONFIG_PATH"
+                          apiVersion: v1
+                          kind: Config
+                          clusters:
+                          - cluster:
+                              certificate-authority: ${CA_CERT}
+                              server: ${SERVER}
+                            name: in-cluster
+                          contexts:
+                          - context:
+                              cluster: in-cluster
+                              namespace: agent-platform
+                              user: sensor-sa
+                            name: in-cluster
+                          current-context: in-cluster
+                          users:
+                          - name: sensor-sa
+                            user:
+                              token: ${TOKEN}
+                          EOF
 
                           echo "$KUBECONFIG_PATH"
                         }


### PR DESCRIPTION
Implemented a new function to ensure the presence of the Argo CLI and download it if not available. Added a method to build a kubeconfig for in-cluster access, allowing for the resumption of suspended workflows using the Argo CLI. This change improves the automation and reliability of workflow management within the GitOps framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Switches workflow resumption in `infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml` to Argo CLI with auto-download and in-cluster kubeconfig.
> 
> - **Workflow resumption enhancement** in `infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml`:
>   - Add `ensure_argo_cli` to detect/download `argo` binary and set `ARGO_BIN`.
>   - Add `build_kubeconfig` to generate in-cluster kubeconfig from service account.
>   - Add `resume_workflow` to resume workflows via `argo resume` with kubeconfig.
>   - Replace direct `kubectl patch ... spec.suspend=false` with `argo`-based resume, including logging and fallback handling on failure.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 1393d3025fc5ca65f6a69e2a863bb9a1099685cf. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->