### PR TITLE
refactor(gitops): enhance kubeconfig generation in play-workflow-sensors.yaml

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -111,26 +111,26 @@ spec:
                           SERVER="https://${KUBERNETES_SERVICE_HOST}:${KUBERNETES_SERVICE_PORT}"
                           TOKEN=$(cat "$TOKEN_FILE")
 
-                          cat <<EOF | sed 's/^ \{26\}//' > "$KUBECONFIG_PATH"
-                          apiVersion: v1
-                          kind: Config
-                          clusters:
-                          - cluster:
-                              certificate-authority: ${CA_CERT}
-                              server: ${SERVER}
-                            name: in-cluster
-                          contexts:
-                          - context:
-                              cluster: in-cluster
-                              namespace: agent-platform
-                              user: sensor-sa
-                            name: in-cluster
-                          current-context: in-cluster
-                          users:
-                          - name: sensor-sa
-                            user:
-                              token: ${TOKEN}
-                          EOF
+                          {
+                            echo "apiVersion: v1"
+                            echo "kind: Config"
+                            echo "clusters:"
+                            echo "  - cluster:"
+                            printf '      certificate-authority: %s\n' "${CA_CERT}"
+                            printf '      server: %s\n' "${SERVER}"
+                            echo "    name: in-cluster"
+                            echo "contexts:"
+                            echo "  - context:"
+                            echo "      cluster: in-cluster"
+                            echo "      namespace: agent-platform"
+                            echo "      user: sensor-sa"
+                            echo "    name: in-cluster"
+                            echo "current-context: in-cluster"
+                            echo "users:"
+                            echo "  - name: sensor-sa"
+                            echo "    user:"
+                            printf '      token: %s\n' "${TOKEN}"
+                          } > "$KUBECONFIG_PATH"
 
                           echo "$KUBECONFIG_PATH"
                         }


### PR DESCRIPTION
Refactored the kubeconfig generation logic to utilize echo and printf for improved readability and maintainability. This change maintains the same functionality while streamlining the configuration process within the GitOps framework.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Replaces heredoc+sed kubeconfig creation with explicit echo/printf construction in `build_kubeconfig`, preserving behavior.
> 
> - **GitOps Sensor (`infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml`)**:
>   - Refactor `build_kubeconfig` to write kubeconfig using `echo`/`printf` instead of heredoc with `sed`, outputting to `KUBECONFIG_PATH`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 855acec1bcd0e8e2a008deaf4da966339bb34436. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->