### PR TITLE
feat(gitops): add stage label advancement for workflow management in play-workflow-sensors.yaml

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -210,7 +210,8 @@ spec:
                         CURRENT_STAGE=$(kubectl get workflow "$WORKFLOW_NAME" -n agent-platform \
                           -o jsonpath='{.metadata.labels.current-stage}' 2>/dev/null || echo "")
                         if [ "$CURRENT_STAGE" != "waiting-pr-created" ]; then
-                          echo "ℹ️ Workflow $WORKFLOW_NAME not in waiting-pr-created (found '$CURRENT_STAGE'); skipping stage update"
+                          echo "ℹ️ Workflow $WORKFLOW_NAME not in waiting-pr-created (found '$CURRENT_STAGE'); skipping stage update and resume"
+                          continue
                         else
                           STAGE_PATCH='{"metadata":{"labels":{"previous-stage":"waiting-pr-created","current-stage":"waiting-quality-complete"}}}'
                           if ! kubectl patch workflow "$WORKFLOW_NAME" -n agent-platform \

--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -201,6 +201,11 @@ spec:
                               --type='merge' -p "$PATCH_JSON"
                           fi
 
+                        # Advance stage label so main workflow can move to quality gate
+                        STAGE_PATCH='{"metadata":{"labels":{"previous-stage":"waiting-pr-created","current-stage":"waiting-quality-complete"}}}'
+                        kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
+                          --type='merge' -p "$STAGE_PATCH"
+
                         echo "Resuming workflow $WORKFLOW_NAME"
                         if ! resume_workflow; then
                           echo "⚠️ Resume attempt failed for $WORKFLOW_NAME"

--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -197,14 +197,28 @@ spec:
                             PATCH_JSON="{\"spec\":{\"arguments\":{\"parameters\":["
                             PATCH_JSON="${PATCH_JSON}{\"name\":\"pr-url\",\"value\":\"$PR_URL\"},"
                             PATCH_JSON="${PATCH_JSON}{\"name\":\"pr-number\",\"value\":\"$PR_NUMBER\"}]}}}"
-                            kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
-                              --type='merge' -p "$PATCH_JSON"
+                          if ! kubectl patch workflow "$WORKFLOW_NAME" -n agent-platform \
+                            --type='merge' -p "$PATCH_JSON"; then
+                            echo "⚠️ Failed to update PR metadata for $WORKFLOW_NAME; skipping"
+                            continue
+                          fi
+                        else
+                          echo "⚠️ Missing PR metadata for $WORKFLOW_NAME; skipping stage advancement"
+                          continue
                           fi
 
-                        # Advance stage label so main workflow can move to quality gate
-                        STAGE_PATCH='{"metadata":{"labels":{"previous-stage":"waiting-pr-created","current-stage":"waiting-quality-complete"}}}'
-                        kubectl patch workflow $WORKFLOW_NAME -n agent-platform \
-                          --type='merge' -p "$STAGE_PATCH"
+                        CURRENT_STAGE=$(kubectl get workflow "$WORKFLOW_NAME" -n agent-platform \
+                          -o jsonpath='{.metadata.labels.current-stage}' 2>/dev/null || echo "")
+                        if [ "$CURRENT_STAGE" != "waiting-pr-created" ]; then
+                          echo "ℹ️ Workflow $WORKFLOW_NAME not in waiting-pr-created (found '$CURRENT_STAGE'); skipping stage update"
+                        else
+                          STAGE_PATCH='{"metadata":{"labels":{"previous-stage":"waiting-pr-created","current-stage":"waiting-quality-complete"}}}'
+                          if ! kubectl patch workflow "$WORKFLOW_NAME" -n agent-platform \
+                            --type='merge' -p "$STAGE_PATCH"; then
+                            echo "⚠️ Failed to advance stage for $WORKFLOW_NAME; skipping resume"
+                            continue
+                          fi
+                        fi
 
                         echo "Resuming workflow $WORKFLOW_NAME"
                         if ! resume_workflow; then


### PR DESCRIPTION
Implemented a new patching mechanism to advance the stage labels in the workflow, allowing the main workflow to progress to the quality gate. This enhancement improves the workflow management process within the GitOps framework by ensuring accurate stage tracking during execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds error-handled PR metadata patching and advances workflow label from `waiting-pr-created` to `waiting-quality-complete` before resuming.
> 
> - **GitOps / Argo Sensor** (`infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml`):
>   - **Stage advancement**: When `current-stage` is `waiting-pr-created`, patch labels to set `previous-stage=waiting-pr-created` and `current-stage=waiting-quality-complete`.
>   - **PR metadata patching**: Patch workflow parameters with `pr-url` and `pr-number`; add error handling and skip on failure or missing metadata.
>   - **Safety checks**: Skip stage update/resume if workflow not in expected stage; continue on failures instead of exiting; improved logging for each step.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit b2f031d5200111767ebbf268eee690a8790f266b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->