### PR TITLE
feat(gitops): add jq installation check in play-workflow-sensors.yaml

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -70,6 +70,15 @@ spec:
                           exit 0
                         fi
 
+                        if ! command -v jq >/dev/null 2>&1; then
+                          echo "Installing jq"
+                          if ! apk add --no-cache jq >/tmp/jq-install.log 2>&1; then
+                            echo "❌ Failed to install jq"
+                            cat /tmp/jq-install.log
+                            exit 1
+                          fi
+                        fi
+
                         ensure_argo_cli() {
                           if command -v argo >/dev/null 2>&1; then
                             ARGO_BIN=$(command -v argo)
@@ -167,8 +176,8 @@ spec:
                           # Check if there's a recent succeeded implementation CodeRun for this task
                           CODERUN=$(kubectl get coderun -n agent-platform \
                             -l task-id=$TASK_ID,workflow-stage=implementation \
-                            --field-selector=status.phase=Succeeded \
-                            -o jsonpath='{.items[0].metadata.name}' 2>/dev/null || echo "")
+                            -o json 2>/dev/null | \
+                            jq -r '.items[] | select(.status.phase=="Succeeded") | .metadata.name' | head -n1 || echo "")
 
                           if [ -z "$CODERUN" ]; then
                             echo "No succeeded implementation CodeRun for task $TASK_ID, skipping"


### PR DESCRIPTION
Introduced a check for the presence of the jq command in the workflow script. If jq is not found, the script attempts to install it using apk, enhancing the script's robustness and ensuring that necessary tools are available for processing JSON data during execution.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a jq installation check and switches CodeRun selection to kubectl JSON output filtered via jq to find the latest succeeded implementation run.
> 
> - **Infra/GitOps** (`infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml`):
>   - **Tooling**: Add `jq` availability check and install via `apk` if missing.
>   - **CodeRun selection**: Replace `--field-selector=status.phase=Succeeded` + jsonpath with `kubectl -o json | jq` filtering for `.status.phase=="Succeeded"`, then `head -n1` to pick a run.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit ebcb137d29d905e23c6cffe9c8869048a227057c. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->