### PR TITLE
fix(gitops): enhance task ID extraction logic in stage-aware-resume-sensor.yaml

### DIFF
--- a/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
@@ -127,14 +127,27 @@ spec:
                         echo "Target Stage: waiting-pr-created"
                         echo "PR Number: {{ .Input.body.pull_request.number }}"
 
-                        # Extract task ID from PR labels using jq (JSON-encode + case-insensitive)
+                        extract_task_id() {
+                          echo "$1" | tr '[:upper:]' '[:lower:]' | grep -oE 'task[-_/ ]*([0-9]+)' | head -n1 | grep -oE '[0-9]+' || true
+                        }
+
+                        TASK_ID=""
                         TASK_LABELS_JSON='{{ .Input.body.pull_request.labels | toJson }}'
-                        TASK_ID=$(echo "$TASK_LABELS_JSON" \
-                          | jq -r '.[] | (.name // "") | ascii_downcase | capture("task-(?<id>[0-9]+)") | .id' \
-                          | head -1)
+                        if [ "$TASK_LABELS_JSON" != "null" ] && [ -n "$TASK_LABELS_JSON" ]; then
+                          TASK_ID=$(echo "$TASK_LABELS_JSON" |
+                            jq -er '.[] | (.name // "") | ascii_downcase | capture("task[-_/ ]*(?<id>[0-9]+)") | .id' 2>/dev/null | head -1 || true)
+                        fi
 
                         if [ -z "$TASK_ID" ]; then
-                          echo "ERROR: No task-* label found on PR"
+                          TASK_ID=$(extract_task_id '{{ .Input.body.pull_request.head.ref }}')
+                        fi
+
+                        if [ -z "$TASK_ID" ]; then
+                          TASK_ID=$(extract_task_id '{{ .Input.body.pull_request.title }}')
+                        fi
+
+                        if [ -z "$TASK_ID" ]; then
+                          echo "ERROR: Unable to determine task ID from PR data"
                           exit 1
                         fi
 


### PR DESCRIPTION
Improved the task ID extraction process by introducing a dedicated function to handle various input formats, including PR labels, branch names, and titles. This change ensures more reliable identification of task IDs, enhancing the robustness of the workflow management in the GitOps framework. Additionally, error handling has been refined to provide clearer feedback when task IDs cannot be determined.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Expands task ID parsing to handle labels, branch names, and PR titles with flexible patterns and clearer errors in `resume-waiting-pr-created`.
> 
> - **GitOps Sensor** (`infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml`):
>   - **`resume-waiting-pr-created` script**:
>     - Add `extract_task_id()` and broaden regex to match `task[-_/ ]*<id>`.
>     - Prefer label-based extraction via `jq`; fall back to PR `head.ref` and `title`.
>     - Initialize `TASK_ID`, guard against `null` labels JSON, and improve error message when no ID is found.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit bca2edfc1fee1f59de2b582b90af77b8cbe41bd9. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->