### PR TITLE
feat(gitops): add PR metadata update function in workflow sensors

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -183,7 +183,7 @@ spec:
                             return 1
                           fi
 
-                          PATCH_JSON=$(echo "$WORKFLOW_JSON" | jq --arg prUrl "$pr_url" --arg prNumber "$pr_number" '
+                          if ! PATCH_JSON=$(echo "$WORKFLOW_JSON" | jq --arg prUrl "$pr_url" --arg prNumber "$pr_number" '
                             .spec.arguments.parameters = (
                               ( .spec.arguments.parameters // [] )
                               | (if (map(.name) | index("pr-url")) != null
@@ -196,7 +196,10 @@ spec:
                                  end)
                             )
                             | {spec:{arguments:{parameters:.spec.arguments.parameters}}}
-                          ')
+                          '); then
+                            echo "⚠️ jq failed while constructing PR metadata patch for $workflow_name"
+                            return 1
+                          fi
 
                           if [ -z "$PATCH_JSON" ]; then
                             echo "⚠️ Failed to construct PR metadata patch payload for $workflow_name"

--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -183,7 +183,8 @@ spec:
                             return 1
                           fi
 
-                          if ! PATCH_JSON=$(echo "$WORKFLOW_JSON" | jq --arg prUrl "$pr_url" --arg prNumber "$pr_number" '
+                          set +e
+                          PATCH_JSON=$(echo "$WORKFLOW_JSON" | jq --arg prUrl "$pr_url" --arg prNumber "$pr_number" '
                             .spec.arguments.parameters = (
                               ( .spec.arguments.parameters // [] )
                               | (if (map(.name) | index("pr-url")) != null
@@ -196,7 +197,11 @@ spec:
                                  end)
                             )
                             | {spec:{arguments:{parameters:.spec.arguments.parameters}}}
-                          '); then
+                          ')
+                          JQ_EXIT=$?
+                          set -e
+
+                          if [ $JQ_EXIT -ne 0 ]; then
                             echo "⚠️ jq failed while constructing PR metadata patch for $workflow_name"
                             return 1
                           fi

--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -172,6 +172,40 @@ spec:
                           fi
                         }
 
+                        update_workflow_pr_metadata() {
+                          local workflow_name="$1"
+                          local pr_url="$2"
+                          local pr_number="$3"
+
+                          WORKFLOW_JSON=$(kubectl get workflow "$workflow_name" -n agent-platform -o json 2>/dev/null)
+                          if [ -z "$WORKFLOW_JSON" ]; then
+                            echo "⚠️ Unable to fetch workflow $workflow_name for PR metadata update"
+                            return 1
+                          fi
+
+                          PATCH_JSON=$(echo "$WORKFLOW_JSON" | jq --arg prUrl "$pr_url" --arg prNumber "$pr_number" '
+                            .spec.arguments.parameters = (
+                              ( .spec.arguments.parameters // [] )
+                              | (if (map(.name) | index("pr-url")) != null
+                                   then map(if .name == "pr-url" then (.value = $prUrl) else . end)
+                                   else . + [{"name":"pr-url","value":$prUrl}]
+                                 end)
+                              | (if (map(.name) | index("pr-number")) != null
+                                   then map(if .name == "pr-number" then (.value = $prNumber) else . end)
+                                   else . + [{"name":"pr-number","value":$prNumber}]
+                                 end)
+                            )
+                            | {spec:{arguments:{parameters:.spec.arguments.parameters}}}
+                          ')
+
+                          if [ -z "$PATCH_JSON" ]; then
+                            echo "⚠️ Failed to construct PR metadata patch payload for $workflow_name"
+                            return 1
+                          fi
+
+                          kubectl patch workflow "$workflow_name" -n agent-platform --type='merge' -p "$PATCH_JSON"
+                        }
+
                         # Process each waiting workflow
                         for WORKFLOW_NAME in $WAITING_WORKFLOWS; do
                           echo "Processing workflow: $WORKFLOW_NAME"
@@ -212,43 +246,38 @@ spec:
                           # Extract PR number from URL
                           PR_NUMBER=$(echo "$PR_URL" | sed 's/.*\/pull\///' | sed 's/[^0-9].*//')
 
+                          if [ -z "$PR_NUMBER" ]; then
+                            echo "⚠️ Unable to parse PR number from URL $PR_URL; skipping"
+                            continue
+                          fi
+
                           echo "PR URL: $PR_URL"
                           echo "PR Number: $PR_NUMBER"
 
-                          # Update workflow parameters with PR info
-                          if [ -n "$PR_NUMBER" ] && [ -n "$PR_URL" ]; then
-                            PATCH_JSON="{\"spec\":{\"arguments\":{\"parameters\":["
-                            PATCH_JSON="${PATCH_JSON}{\"name\":\"pr-url\",\"value\":\"$PR_URL\"},"
-                            PATCH_JSON="${PATCH_JSON}{\"name\":\"pr-number\",\"value\":\"$PR_NUMBER\"}]}}}"
-                          if ! kubectl patch workflow "$WORKFLOW_NAME" -n agent-platform \
-                            --type='merge' -p "$PATCH_JSON"; then
+                          if ! update_workflow_pr_metadata "$WORKFLOW_NAME" "$PR_URL" "$PR_NUMBER"; then
                             echo "⚠️ Failed to update PR metadata for $WORKFLOW_NAME; skipping"
                             continue
                           fi
-                        else
-                          echo "⚠️ Missing PR metadata for $WORKFLOW_NAME; skipping stage advancement"
-                          continue
+
+                          CURRENT_STAGE=$(kubectl get workflow "$WORKFLOW_NAME" -n agent-platform \
+                            -o jsonpath='{.metadata.labels.current-stage}' 2>/dev/null || echo "")
+                          if [ "$CURRENT_STAGE" != "waiting-pr-created" ]; then
+                            echo "ℹ️ Workflow $WORKFLOW_NAME not in waiting-pr-created (found '$CURRENT_STAGE'); skipping stage update and resume"
+                            continue
+                          else
+                            STAGE_PATCH='{"metadata":{"labels":{"previous-stage":"waiting-pr-created","current-stage":"waiting-quality-complete"}}}'
+                            if ! kubectl patch workflow "$WORKFLOW_NAME" -n agent-platform \
+                              --type='merge' -p "$STAGE_PATCH"; then
+                              echo "⚠️ Failed to advance stage for $WORKFLOW_NAME; skipping resume"
+                              continue
+                            fi
                           fi
 
-                        CURRENT_STAGE=$(kubectl get workflow "$WORKFLOW_NAME" -n agent-platform \
-                          -o jsonpath='{.metadata.labels.current-stage}' 2>/dev/null || echo "")
-                        if [ "$CURRENT_STAGE" != "waiting-pr-created" ]; then
-                          echo "ℹ️ Workflow $WORKFLOW_NAME not in waiting-pr-created (found '$CURRENT_STAGE'); skipping stage update and resume"
-                          continue
-                        else
-                          STAGE_PATCH='{"metadata":{"labels":{"previous-stage":"waiting-pr-created","current-stage":"waiting-quality-complete"}}}'
-                          if ! kubectl patch workflow "$WORKFLOW_NAME" -n agent-platform \
-                            --type='merge' -p "$STAGE_PATCH"; then
-                            echo "⚠️ Failed to advance stage for $WORKFLOW_NAME; skipping resume"
+                          echo "Resuming workflow $WORKFLOW_NAME"
+                          if ! resume_workflow; then
+                            echo "⚠️ Resume attempt failed for $WORKFLOW_NAME"
                             continue
                           fi
-                        fi
-
-                        echo "Resuming workflow $WORKFLOW_NAME"
-                        if ! resume_workflow; then
-                          echo "⚠️ Resume attempt failed for $WORKFLOW_NAME"
-                          continue
-                        fi
                         done
 
                         echo "Finished processing waiting workflows"

--- a/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
@@ -134,7 +134,7 @@ spec:
                             return 1
                           fi
 
-                          PATCH_JSON=$(echo "$WORKFLOW_JSON" | jq --arg prUrl "$pr_url" --arg prNumber "$pr_number" '
+                          if ! PATCH_JSON=$(echo "$WORKFLOW_JSON" | jq --arg prUrl "$pr_url" --arg prNumber "$pr_number" '
                             .spec.arguments.parameters = (
                               ( .spec.arguments.parameters // [] )
                               | (if (map(.name) | index("pr-url")) != null
@@ -147,7 +147,10 @@ spec:
                                  end)
                             )
                             | {spec:{arguments:{parameters:.spec.arguments.parameters}}}
-                          ')
+                          '); then
+                            echo "ERROR: jq failed while constructing PR metadata patch for $workflow_name"
+                            return 1
+                          fi
 
                           if [ -z "$PATCH_JSON" ]; then
                             echo "ERROR: Failed to construct PR metadata patch payload for $workflow_name"

--- a/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
@@ -134,7 +134,8 @@ spec:
                             return 1
                           fi
 
-                          if ! PATCH_JSON=$(echo "$WORKFLOW_JSON" | jq --arg prUrl "$pr_url" --arg prNumber "$pr_number" '
+                          set +e
+                          PATCH_JSON=$(echo "$WORKFLOW_JSON" | jq --arg prUrl "$pr_url" --arg prNumber "$pr_number" '
                             .spec.arguments.parameters = (
                               ( .spec.arguments.parameters // [] )
                               | (if (map(.name) | index("pr-url")) != null
@@ -147,7 +148,11 @@ spec:
                                  end)
                             )
                             | {spec:{arguments:{parameters:.spec.arguments.parameters}}}
-                          '); then
+                          ')
+                          JQ_EXIT=$?
+                          set -e
+
+                          if [ $JQ_EXIT -ne 0 ]; then
                             echo "ERROR: jq failed while constructing PR metadata patch for $workflow_name"
                             return 1
                           fi

--- a/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
@@ -123,6 +123,35 @@ spec:
                           fi
                         fi
 
+                        update_workflow_pr_metadata() {
+                          local workflow_name="$1"
+                          local pr_url="$2"
+                          local pr_number="$3"
+
+                          WORKFLOW_JSON=$(kubectl get workflow "$workflow_name" -n agent-platform -o json 2>/dev/null)
+                          if [ -z "$WORKFLOW_JSON" ]; then
+                            echo "ERROR: Unable to fetch workflow $workflow_name for PR metadata update"
+                            return 1
+                          fi
+
+                          PATCH_JSON=$(echo "$WORKFLOW_JSON" | jq --arg prUrl "$pr_url" --arg prNumber "$pr_number" '
+                            .spec.arguments.parameters = (
+                              ( .spec.arguments.parameters // [] )
+                              | (if (map(.name) | index("pr-url")) != null
+                                   then map(if .name == "pr-url" then (.value = $prUrl) else . end)
+                                   else . + [{"name":"pr-url","value":$prUrl}]
+                                 end)
+                              | (if (map(.name) | index("pr-number")) != null
+                                   then map(if .name == "pr-number" then (.value = $prNumber) else . end)
+                                   else . + [{"name":"pr-number","value":$prNumber}]
+                                 end)
+                            )
+                            | {spec:{arguments:{parameters:.spec.arguments.parameters}}}
+                          ')
+
+                          kubectl patch workflow "$workflow_name" -n agent-platform --type='merge' -p "$PATCH_JSON"
+                        }
+
                         echo "=== Stage-Aware Workflow Resume ==="
                         echo "Target Stage: waiting-pr-created"
                         echo "PR Number: {{ .Input.body.pull_request.number }}"
@@ -176,19 +205,10 @@ spec:
                           echo "Found workflow at correct stage, resuming..."
 
                           # Update workflow parameters with PR details
-                          kubectl patch workflow $WORKFLOW_NAME \
-                            -n agent-platform \
-                            --type='merge' \
-                            --patch='{
-                              "spec": {
-                                "arguments": {
-                                  "parameters": [
-                                    {"name": "pr-url", "value": "{{ .Input.body.pull_request.html_url }}"},
-                                    {"name": "pr-number", "value": "{{ .Input.body.pull_request.number }}"}
-                                  ]
-                                }
-                              }
-                            }'
+                          if ! update_workflow_pr_metadata "$WORKFLOW_NAME" "{{ .Input.body.pull_request.html_url }}" "{{ .Input.body.pull_request.number }}"; then
+                            echo "ERROR: Failed to update PR metadata on $WORKFLOW_NAME"
+                            exit 1
+                          fi
 
                           # Resume the workflow
                           kubectl patch workflow $WORKFLOW_NAME \

--- a/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
@@ -149,6 +149,11 @@ spec:
                             | {spec:{arguments:{parameters:.spec.arguments.parameters}}}
                           ')
 
+                          if [ -z "$PATCH_JSON" ]; then
+                            echo "ERROR: Failed to construct PR metadata patch payload for $workflow_name"
+                            return 1
+                          fi
+
                           kubectl patch workflow "$workflow_name" -n agent-platform --type='merge' -p "$PATCH_JSON"
                         }
 


### PR DESCRIPTION
Introduced a new function to update PR metadata in workflows for both play-workflow-sensors.yaml and stage-aware-resume-sensor.yaml. This enhancement allows the workflows to dynamically include PR URLs and numbers, improving the tracking and management of pull requests within the GitOps framework. The new function enhances error handling and ensures that workflows are updated correctly with relevant PR information.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds a jq-based function to patch PR URL/number into workflows and refactors play/stage-aware sensors to use it with stronger validation and error handling.
> 
> - **GitOps Sensors**:
>   - **Reusable PR metadata update**: Introduces `update_workflow_pr_metadata` that fetches workflow JSON and merges `spec.arguments.parameters` with `pr-url` and `pr-number` via `jq`, with error checks.
>   - **play-workflow-sensors.yaml**:
>     - Replaces inline patch JSON with `update_workflow_pr_metadata` and validates parsed `PR_NUMBER` before proceeding.
>     - Keeps stage gate `waiting-pr-created` and resume flow, with clearer branching and failure handling.
>   - **stage-aware-resume-sensor.yaml**:
>     - Replaces inline patching of PR details with `update_workflow_pr_metadata`; exits on failure.
>     - Maintains stage check and resume logic; minor log/message improvements.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit e1ac039241966448cfc22187bea0e3d224043a49. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->