### PR TITLE
feat(github): enhance PR detection logic by branch pattern matching

### DIFF
--- a/controller/src/tasks/github.rs
+++ b/controller/src/tasks/github.rs
@@ -1,7 +1,7 @@
 //! GitHub API integration for fallback PR detection
 
 use anyhow::{Context as AnyhowContext, Result};
-use octocrab::Octocrab;
+use octocrab::{models::pulls::PullRequest, Octocrab};
 use tracing::{info, warn};
 
 use crate::crds::coderun::CodeRun;
@@ -12,11 +12,10 @@ pub async fn check_github_for_pr_by_branch(
     github_token: Option<&str>,
 ) -> Result<Option<String>> {
     let task_id = code_run.spec.task_id;
-    let expected_branch = format!("task-{task_id}");
 
     info!(
-        "Checking GitHub API for PR with branch: {}",
-        expected_branch
+        "Checking GitHub API for PR containing branch pattern: task-{}",
+        task_id
     );
 
     // Parse repository URL to extract owner/repo
@@ -34,24 +33,58 @@ pub async fn check_github_for_pr_by_branch(
         Octocrab::builder().build()?
     };
 
-    // Search for PRs with the expected branch
-    let pulls = octocrab
+    // Search for PRs whose head ref matches task-specific branch patterns
+    let mut page = octocrab
         .pulls(&owner, &repo)
         .list()
         .state(octocrab::params::State::Open)
-        .head(format!("{owner}:{expected_branch}"))
+        .per_page(50)
         .send()
         .await
         .with_context(|| format!("Failed to search for PRs in {owner}/{repo}"))?;
 
-    if let Some(pr) = pulls.items.first() {
-        let pr_url = pr.html_url.as_ref().map(|url| url.to_string());
-        info!("Found PR via GitHub API: {:?}", pr_url);
-        Ok(pr_url)
-    } else {
-        info!("No PR found for branch: {}", expected_branch);
-        Ok(None)
+    loop {
+        if let Some(pr) = page
+            .items
+            .iter()
+            .find(|pr| branch_matches(task_id, &pr.head.ref_field))
+        {
+            let pr_url = pr
+                .html_url
+                .as_ref()
+                .map(|url| url.to_string())
+                .unwrap_or_else(|| pr.url.clone());
+            info!("Found PR via GitHub API for task {}: {}", task_id, pr_url);
+            return Ok(Some(pr_url));
+        }
+
+        match next_page(&octocrab, &page).await? {
+            Some(next) => page = next,
+            None => {
+                info!("No PR found for task branch patterns: task-{}", task_id);
+                return Ok(None);
+            }
+        }
     }
+}
+
+async fn next_page(
+    client: &Octocrab,
+    current: &octocrab::Page<PullRequest>,
+) -> Result<Option<octocrab::Page<PullRequest>>> {
+    client
+        .get_page(&current.next)
+        .await
+        .with_context(|| "Failed to fetch next page of pull requests".to_string())
+}
+
+fn branch_matches(task_id: u32, head_ref: &str) -> bool {
+    let base = format!("task-{task_id}");
+
+    head_ref == base
+        || head_ref == format!("feature/{base}")
+        || head_ref.starts_with(&format!("{base}-"))
+        || head_ref.starts_with(&format!("feature/{base}-"))
 }
 
 /// Parse repository URL to extract owner and repo name
@@ -149,5 +182,20 @@ mod tests {
 
         // Invalid format
         assert!(parse_repository_url("invalid").is_err());
+    }
+
+    #[test]
+    fn test_branch_matches() {
+        assert!(branch_matches(1, "task-1"));
+        assert!(branch_matches(1, "task-1-implementation"));
+        assert!(branch_matches(1, "feature/task-1"));
+        assert!(branch_matches(1, "feature/task-1-implementation"));
+        assert!(branch_matches(
+            1,
+            "feature/task-1-implementation-20250101121212"
+        ));
+        assert!(!branch_matches(1, "task-10"));
+        assert!(!branch_matches(1, "feature/task-10-implementation"));
+        assert!(!branch_matches(1, "main"));
     }
 }


### PR DESCRIPTION
Refactored the GitHub API integration to improve the detection of pull requests based on task-specific branch patterns. The new implementation allows for matching branches that follow a specific naming convention, including variations like "feature/task-{task_id}". Additionally, a new helper function for pagination has been introduced to handle multiple pages of pull requests. Unit tests for the branch matching logic have also been added to ensure correctness.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Improves GitHub PR detection by matching task-based branch patterns, paginating open PRs, and validating PR origin repo, with new helper functions and tests.
> 
> - **Backend – GitHub PR detection (`controller/src/tasks/github.rs`)**:
>   - Match task-based branch patterns in PR head refs via `branch_matches` (e.g., `task-{id}`, `feature/task-{id}`, suffix variants).
>   - Paginate open PRs using `next_page` and search up to 50 per page.
>   - Validate PR origin repository with `pr_origin_matches`/`repo_identity_matches` to ensure owner/repo match; construct fallback PR URL if `html_url` missing.
>   - Logging updated to indicate pattern-based search.
> - **Tests**:
>   - Add unit tests for `branch_matches` and `repo_identity_matches` variants.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 977941ab53915fae1b25f92fb0496d319499ab25. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->