### PR TITLE
feat(github-webhooks): enhance task ID retrieval from PR payload

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -335,8 +335,61 @@ spec:
                         PR_API_URL="https://api.github.com/repos/${REPO}/issues/${PR_NUMBER}"
                         TARGET_LABEL="needs-cleo"
 
+                        AUTH_HEADER=""
+                        INSTALLATION_TOKEN=""
+                        if INSTALLATION_TOKEN=$(get_installation_token); then
+                          AUTH_HEADER="Authorization: Bearer $INSTALLATION_TOKEN"
+                          echo "Using GitHub App installation token for API calls"
+                        else
+                          echo "ℹ️ Proceeding without GitHub App token (unauthenticated GitHub API)"
+                        fi
+
                         extract_task_id() {
                           echo "$1" | tr '[:upper:]' '[:lower:]' | grep -oE 'task[-_/ ]*([0-9]+)' | head -n1 | grep -oE '[0-9]+' || true
+                        }
+
+                        fetch_task_id_via_api() {
+                          local response label_name candidate title body
+
+                          if [ -n "$AUTH_HEADER" ]; then
+                            response=$(curl -s -L -H "Accept: application/vnd.github+json" -H "$AUTH_HEADER" "$PR_API_URL")
+                          else
+                            response=$(curl -s -L -H "Accept: application/vnd.github+json" "$PR_API_URL")
+                          fi
+
+                          if [ -z "$response" ] || [ "$response" = "null" ]; then
+                            echo ""
+                            return 1
+                          fi
+
+                          while IFS= read -r label_name; do
+                            candidate=$(extract_task_id "$label_name")
+                            if [ -n "$candidate" ]; then
+                              echo "$candidate"
+                              return 0
+                            fi
+                          done < <(echo "$response" | jq -r '(.labels // [])[]?.name // ""')
+
+                          title=$(echo "$response" | jq -r '.title // ""')
+                          if [ -n "$title" ]; then
+                            candidate=$(extract_task_id "$title")
+                            if [ -n "$candidate" ]; then
+                              echo "$candidate"
+                              return 0
+                            fi
+                          fi
+
+                          body=$(echo "$response" | jq -r '.body // ""')
+                          if [ -n "$body" ]; then
+                            candidate=$(extract_task_id "$body")
+                            if [ -n "$candidate" ]; then
+                              echo "$candidate"
+                              return 0
+                            fi
+                          fi
+
+                          echo ""
+                          return 1
                         }
 
                         TASK_ID=""
@@ -355,20 +408,16 @@ spec:
                         fi
 
                         if [ -z "$TASK_ID" ]; then
+                          echo "ℹ️ Task ID not present in webhook payload; querying GitHub API for labels/title/body"
+                          TASK_ID=$(fetch_task_id_via_api || true)
+                        fi
+
+                        if [ -z "$TASK_ID" ]; then
                           echo "❌ Unable to determine task ID from PR payload"
                           exit 1
                         fi
 
                         echo "Task ID: $TASK_ID"
-
-                        AUTH_HEADER=""
-                        INSTALLATION_TOKEN=""
-                        if INSTALLATION_TOKEN=$(get_installation_token); then
-                          AUTH_HEADER="Authorization: Bearer $INSTALLATION_TOKEN"
-                          echo "Using GitHub App installation token for API calls"
-                        else
-                          echo "ℹ️ Proceeding without GitHub App token (unauthenticated GitHub API)"
-                        fi
 
                         echo "Waiting for Rex to apply '$TARGET_LABEL' label to PR #$PR_NUMBER..."
                         MAX_LABEL_ATTEMPTS=90


### PR DESCRIPTION
Added functionality to fetch task IDs from GitHub API when not present in the webhook payload. This includes implementing an authentication mechanism using a GitHub App installation token, improving the reliability of task ID extraction from PR labels, titles, and bodies. This change enhances the automation of workflow sensors by ensuring task IDs are accurately retrieved, even in cases of missing data in the initial payload.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit dafe0b69af6bf6ce1dfd9266bf4c64b56d76368e. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->