### PR TITLE
Fix/factory-play

### DIFF
--- a/infra/charts/controller/agent-templates/code/cursor/container-base.sh.hbs
+++ b/infra/charts/controller/agent-templates/code/cursor/container-base.sh.hbs
@@ -685,11 +685,11 @@ is_valid_cfg() {
 }
 
 if is_valid_cfg "$WORKSPACE_CFG"; then
-  cp "$WORKSPACE_CFG" "$TARGET_CFG"
+  cp -f "$WORKSPACE_CFG" "$TARGET_CFG"
   echo "✓ Using MCP client config from workspace: $TARGET_CFG"
 elif is_valid_cfg "$SOURCE_CFG"; then
-  cp "$SOURCE_CFG" "$WORKSPACE_CFG"
-  cp "$SOURCE_CFG" "$TARGET_CFG"
+  cp -f "$SOURCE_CFG" "$WORKSPACE_CFG"
+  cp -f "$SOURCE_CFG" "$TARGET_CFG"
   echo "✓ Restored MCP client config from source: $TARGET_CFG"
 else
   echo "❌ No valid client-config.json available (checked $WORKSPACE_CFG and $SOURCE_CFG)"

--- a/infra/charts/controller/agent-templates/code/opencode/container-base.sh.hbs
+++ b/infra/charts/controller/agent-templates/code/opencode/container-base.sh.hbs
@@ -1257,10 +1257,12 @@ done
 
 if [ $SUCCESS -ne 1 ]; then
   echo "⚠️ OpenCode did not confirm task completion after $MAX_RETRIES attempts"
-  EXIT_CODE=0
+  echo "❌ Task incomplete - marking as FAILED"
+  EXIT_CODE=1  # FAIL the job so it doesn't appear successful
 else
+  echo "✅ OpenCode confirmed task completion"
   if [ ${OPENCODE_EXIT:-0} -ne 0 ]; then
-    echo "⚠️ OpenCode returned exit code ${OPENCODE_EXIT}; treating as success"
+    echo "⚠️ OpenCode returned non-zero exit code ${OPENCODE_EXIT}, but completion probe passed"
   fi
   EXIT_CODE=0
 fi


### PR DESCRIPTION
Updated the OpenCode container base script to enhance task completion feedback. The script now marks tasks as FAILED when OpenCode does not confirm completion after retries, ensuring clearer error reporting. Additionally, it provides more informative messages regarding non-zero exit codes from OpenCode, improving user guidance during execution.

Affected file:
- container-base.sh.hbs