### PR TITLE
feat(config): add maxRetries parameter for OpenCode agent and update templates

### DIFF
--- a/cto-config.json
+++ b/cto-config.json
@@ -44,7 +44,8 @@
       "service": "cli-agnostic-platform",
       "docsRepository": "5dlabs/cto",
       "docsProjectDirectory": "cli-agnostic-platform",
-      "workingDirectory": "cli-agnostic-platform"
+      "workingDirectory": "cli-agnostic-platform",
+      "maxRetries": 10
     },
     "docs_ingest": {
       "model": "claude-sonnet-4-20250514",
@@ -158,7 +159,7 @@
       "tools": {
         "remote": [
           "brave_search_brave_web_search",
-          "context7_get_library_docs"
+          "context7_get_library_docs",
           "agent_docs_rust_query",
           "agent_docs_codex_query",
           "agent_docs_cursor_query",

--- a/cto-config.template.json
+++ b/cto-config.template.json
@@ -19,7 +19,7 @@
       "repository": "https://github.com/your-org/your-target-repo",
       "docsRepository": "https://github.com/your-org/your-docs-repo",
       "docsProjectDirectory": "projects/your-project",
-      "service": "your-service-name",
+      "service": "cto",
       "cli": "codex"
     },
     "_comment_intake": "Default values for intake() tool - project intake workflows",
@@ -49,7 +49,8 @@
       "service": "your-test-service",
       "docsRepository": "your-org/your-test-repo",
       "docsProjectDirectory": "docs",
-      "workingDirectory": "/path/to/your/test/workspace"
+      "workingDirectory": "/path/to/your/test/workspace",
+      "maxRetries": 10
     },
     "_comment_docs_ingest": "Default values for docs ingest workflows",
     "docs_ingest": {

--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -133,6 +133,9 @@ spec:
       - name: task-requirements
         description: "Base64-encoded requirements.yaml content for all agents"
         value: ""
+      - name: opencode-max-retries
+        description: "Maximum retry attempts for OpenCode agent executions"
+        value: "10"
 
   # Workflow instance naming pattern
   onExit: cleanup-handler
@@ -831,6 +834,7 @@ spec:
               SERVICE_NAME: "{{`{{workflow.parameters.service}}`}}"
               RUN_NAME: "{{`{{workflow.name}}`}}"
               TASK_ID: "{{`{{inputs.parameters.task-id}}`}}"
+              OPENCODE_MAX_RETRIES: "{{`{{workflow.parameters.opencode-max-retries}}`}}"
 
     # Helper to reliably resolve the created CodeRun name before waiting for completion
     - name: resolve-coderun-name

--- a/mcp/src/tools.rs
+++ b/mcp/src/tools.rs
@@ -120,6 +120,10 @@ fn get_play_schema(agents: &HashMap<String, crate::AgentConfig>) -> Value {
                     "type": "string",
                     "description": "Claude model to use for all agents (optional, defaults to configuration)"
                 },
+                "opencode_max_retries": {
+                    "type": "integer",
+                    "description": "Override maximum retry attempts for OpenCode runs (defaults to configuration)"
+                },
                 "cli": {
                     "type": "string",
                     "description": "CLI tool to use for all agents (optional, defaults to configuration)"


### PR DESCRIPTION
- Introduced a new `maxRetries` parameter in `cto-config.json` and `cto-config.template.json` to allow configuration of maximum retry attempts for OpenCode agent executions.
- Updated the `play-workflow-template.yaml` to include the new `opencode-max-retries` parameter.
- Modified the MCP server code to handle the new `max_retries` field in agent configurations and to utilize it in the play workflow logic.
- Enhanced the schema in `tools.rs` to document the new `opencode_max_retries` parameter.

These changes improve the flexibility and configurability of retry logic for OpenCode executions.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Introduces a configurable maxRetries for OpenCode runs, plumbed from config → MCP → Argo workflow (param/env) with CLI schema support.
> 
> - **Config**:
>   - Add `maxRetries: 10` to `defaults.play` in `cto-config.json` and `cto-config.template.json`.
>   - Set `defaults.code.service` to `cto` in template.
>   - Minor tools list fix in `agents.cipher.tools.remote`.
> - **Workflow** (`infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml`):
>   - Add parameter `opencode-max-retries` (default `"10"`).
>   - Export `OPENCODE_MAX_RETRIES` env var into `CodeRun` pods.
> - **MCP Server**:
>   - Parse and expose new fields:
>     - In `AgentConfig` and `PlayDefaults`: optional `maxRetries`.
>   - Play logic (`mcp/src/main.rs`):
>     - Resolve `opencode_max_retries` from explicit arg → agent `maxRetries` → `defaults.play.maxRetries` → fallback `10`.
>     - Pass as Argo param `opencode-max-retries` and log debug value.
>   - Tools schema (`mcp/src/tools.rs`): document `opencode_max_retries` integer input for `play` tool.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 9ed9096146e1cd72555cd1c287e3dbc5dfc02ce2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->