### PR TITLE
debug(sensors): add workflow parameter dump for PR created events

### DIFF
--- a/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
+++ b/infra/gitops/resources/github-webhooks/play-workflow-sensors.yaml
@@ -360,6 +360,17 @@ spec:
                         ensure_jq
                         ensure_openssl
 
+                        # Debug: Print all workflow parameters to diagnose template evaluation
+                        echo "=== DEBUG: Workflow Parameters ==="
+                        echo "pr-branch-ref: {{workflow.parameters.pr-branch-ref}}"
+                        echo "pr-title: {{workflow.parameters.pr-title}}"
+                        echo "pr-number: {{workflow.parameters.pr-number}}"
+                        echo "pr-url: {{workflow.parameters.pr-url}}"
+                        echo "pr-labels: {{workflow.parameters.pr-labels}}"
+                        echo "repo-owner: {{workflow.parameters.repo-owner}}"
+                        echo "repo-name: {{workflow.parameters.repo-name}}"
+                        echo "=================================="
+
                         OWNER="{{workflow.parameters.repo-owner}}"
                         REPO_NAME="{{workflow.parameters.repo-name}}"
                         REPO="${OWNER}/${REPO_NAME}"


### PR DESCRIPTION
Add debug output to print all workflow parameters received by the
resume workflow to diagnose why sensor template expressions like
{{ .Input.body.pull_request.head.ref }} aren't being evaluated.

This will help determine if the issue is with Argo Events sensor
template evaluation or workflow parameter passing.