### PR TITLE
chore: auto-update agent-templates ConfigMap

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -294,22 +294,17 @@ spec:
                   value: "{{`{{workflow.parameters.implementation-cli}}`}}"
                 - name: model
                   value: "{{`{{workflow.parameters.implementation-model}}`}}"
-        - - name: update-to-waiting-pr-created
+        # Note: No longer suspending for PR created event - implementation-cycle already
+        # verified PR exists via check-or-wait-for-pr polling. Webhook-based resume was
+        # creating race conditions where PR webhook fired before suspend point was reached.
+        - - name: update-to-waiting-quality
             template: update-workflow-stage
             arguments:
               parameters:
                 - name: new-stage
-                  value: "waiting-pr-created"
+                  value: "waiting-quality-complete"
                 - name: verify-update
                   value: "true"
-        - - name: wait-for-pr-created
-            template: suspend-for-event
-            arguments:
-              parameters:
-                - name: event-type
-                  value: "pr-created"
-                - name: stage-name
-                  value: "waiting-pr-created"
         - - name: quality-work
             template: agent-coderun
             arguments:
@@ -947,6 +942,8 @@ spec:
             # Define valid transitions (Rex → Cleo → Tess flow)
             case $current_stage in
               "pending")
+                # Allow direct transition to waiting-quality-complete (skipping waiting-pr-created)
+                [[ $new_stage == "waiting-quality-complete" ]] && return 0
                 [[ $new_stage == "waiting-pr-created" ]] && return 0
                 ;;
               "waiting-pr-created")

--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -297,12 +297,12 @@ spec:
         # Note: No longer suspending for PR created event - implementation-cycle already
         # verified PR exists via check-or-wait-for-pr polling. Webhook-based resume was
         # creating race conditions where PR webhook fired before suspend point was reached.
-        - - name: update-to-waiting-quality
+        - - name: update-to-quality-in-progress
             template: update-workflow-stage
             arguments:
               parameters:
                 - name: new-stage
-                  value: "waiting-quality-complete"
+                  value: "quality-in-progress"
                 - name: verify-update
                   value: "true"
         - - name: quality-work
@@ -942,11 +942,17 @@ spec:
             # Define valid transitions (Rex → Cleo → Tess flow)
             case $current_stage in
               "pending")
-                # Allow direct transition to waiting-quality-complete (skipping waiting-pr-created)
+                # Primary path: pending → quality-in-progress
+                [[ $new_stage == "quality-in-progress" ]] && return 0
+                # Legacy paths for backward compatibility
                 [[ $new_stage == "waiting-quality-complete" ]] && return 0
                 [[ $new_stage == "waiting-pr-created" ]] && return 0
                 ;;
               "waiting-pr-created")
+                [[ $new_stage == "quality-in-progress" ]] && return 0
+                [[ $new_stage == "waiting-quality-complete" ]] && return 0
+                ;;
+              "quality-in-progress")
                 [[ $new_stage == "waiting-quality-complete" ]] && return 0
                 ;;
               "waiting-quality-complete")


### PR DESCRIPTION
This commit was automatically generated by the CI pipeline
to keep the templates ConfigMap in sync with source files.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Eliminates the PR-created webhook suspend in favor of polling and updates stage transitions to go directly from pending to waiting-quality-complete.
> 
> - **Workflow Orchestration** (`infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml`):
>   - **Implementation → Quality flow**:
>     - Remove `suspend-for-event` wait for `pr-created` and the preceding `update-to-waiting-pr-created` step.
>     - Replace with `update-to-waiting-quality` setting `new-stage` to `"waiting-quality-complete"`.
>     - Add notes explaining switch from webhook resume to polling due to race conditions.
>   - **Stage validation** (`update-workflow-stage`):
>     - Permit transition from `pending` directly to `waiting-quality-complete` (skipping `waiting-pr-created`).
>     - Keep existing transitions from `waiting-pr-created` → `waiting-quality-complete` and onward unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 4fbd27920da98ea1a7b02383289de41eca6df32b. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->