### PR TITLE
chore(chart): regenerate agent templates ConfigMaps

### DIFF
--- a/infra/charts/controller/Makefile
+++ b/infra/charts/controller/Makefile
@@ -30,7 +30,7 @@ package: ## Package the Helm chart
 .PHONY: update-templates
 update-templates: generate-templates ## Update templates and prepare for commit
 	@echo "Templates updated. Don't forget to commit the changes!"
-	@git status templates/agent-templates-static.yaml
+	@git status templates/agent-templates-*.yaml
 
 .PHONY: validate
 validate: lint template ## Validate the chart (lint + template generation)


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Migrate from a single static agent templates ConfigMap to multiple split ConfigMaps, updating apply/update scripts and Makefile references.
> 
> - **Scripts**:
>   - **Apply**: `scripts/apply-agent-templates-configmap.sh` now renders and applies multiple split ConfigMaps (`agent-templates-*.yaml`) in a loop instead of a single static ConfigMap.
>   - **Update**: `scripts/update-templates.sh` regenerates split ConfigMaps, detects per-template changes, prints checksums, and commits updates using `templates/agent-templates-*.yaml`.
> - **Helm Chart**:
>   - **Makefile**: `update-templates` target now checks `templates/agent-templates-*.yaml` instead of the single static file.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 31b51cb9106fca76c647edb5a879909d4c5cd7f1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->