### PR TITLE
fix(workflows): add missing template name for resolve-coderun-name

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -526,7 +526,7 @@ spec:
 
             pr_url=$(echo "$resp" | jq -r '.[] | select(.pull_request != null) | .html_url' | head -n1)
             pr_number=$(echo "$resp" | jq -r '.[] | select(.pull_request != null) | .number' | head -n1)
-            
+
             # Fallback: if implementation stage and not found with both labels, try just task label
             if [ -z "$pr_number" ] || [ "$pr_number" = "null" ]; then
               if [ "$STAGE" != "quality" ] && [ "$STAGE" != "testing" ]; then
@@ -854,6 +854,7 @@ spec:
               OPENCODE_VERBOSE: "{{`{{workflow.parameters.opencode-verbose}}`}}"
 
     # Helper to reliably resolve the created CodeRun name before waiting for completion
+    - name: resolve-coderun-name
       inputs:
         parameters:
           - name: stage


### PR DESCRIPTION
Fixes Argo workflow error 'multiple template types specified' by adding
the missing template name declaration for resolve-coderun-name. This template
was previously missing its '- name:' declaration, causing its inputs, outputs,
and script sections to be incorrectly attached to the create-coderun-resource
template above it.

This resulted in create-coderun-resource having both 'resource' and 'script'
template types, which violates Argo's requirement that each template have
exactly one type.

Also cleaned up trailing whitespace on line 529.