### PR TITLE
fix(workflow): allow direct transition from quality-in-progress to waiting-ready-for-qa

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -969,6 +969,7 @@ spec:
                 ;;
               "quality-in-progress")
                 [[ $new_stage == "waiting-quality-complete" ]] && return 0
+                [[ $new_stage == "waiting-ready-for-qa" ]] && return 0
                 ;;
               "waiting-quality-complete")
                 [[ $new_stage == "waiting-ready-for-qa" ]] && return 0


### PR DESCRIPTION
## Problem
After removing the wait-for-quality-complete suspend point, workflows were getting stuck because the stage transition validation still required going through that intermediate stage.

## Solution
Added  as a valid transition target from  stage.

## Impact
- Fixes workflow getting stuck after Tess completes
- Allows proper progression to PR merge waiting state
- Unblocks task 2 from starting after task 1 PR is merged

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 5903f07ea8c52f8694728b74efac40ad874581d2. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->