### PR TITLE
fix(sensors): extract task ID from PR labels as fallback

### DIFF
--- a/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
+++ b/infra/charts/controller/templates/workflowtemplates/play-workflow-template.yaml
@@ -969,6 +969,7 @@ spec:
                 ;;
               "quality-in-progress")
                 [[ $new_stage == "waiting-quality-complete" ]] && return 0
+                [[ $new_stage == "waiting-ready-for-qa" ]] && return 0
                 ;;
               "waiting-quality-complete")
                 [[ $new_stage == "waiting-ready-for-qa" ]] && return 0

--- a/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/merge-to-main-sensor.yaml
@@ -248,10 +248,24 @@ spec:
                         PR_TITLE="{{workflow.parameters.pr-title}}"
                         TASK_ID=$(echo "$PR_TITLE" | grep -oE '[Tt]ask[- ]?([0-9]+)' | sed -E 's/[Tt]ask[- ]?//')
 
+                        # Fallback: Extract from PR labels if not in title
                         if [ -z "$TASK_ID" ]; then
-                          echo "⚠️ No task ID found in PR title, checking PR body and branch..."
-                          # Could also check branch name or PR body for task ID
-                          exit 0
+                          echo "⚠️ No task ID found in PR title, checking labels..."
+                          PR_URL="{{workflow.parameters.pr-url}}"
+                          REPO_PATH=$(echo "$PR_URL" | sed -E 's|https://github.com/([^/]+/[^/]+)/pull/.*|\1|')
+                          PR_NUMBER="{{workflow.parameters.pr-number}}"
+                          
+                          PR_JSON=$(curl -s -H "Authorization: Bearer $GITHUB_TOKEN" \
+                            "https://api.github.com/repos/$REPO_PATH/issues/$PR_NUMBER")
+                          
+                          TASK_ID=$(echo "$PR_JSON" | jq -r '.labels[].name' | grep -oE '^task-([0-9]+)$' | sed 's/task-//' | head -1)
+                          
+                          if [ -n "$TASK_ID" ]; then
+                            echo "✅ Found task ID from labels: $TASK_ID"
+                          else
+                            echo "⚠️ No task ID found in PR title or labels"
+                            exit 0
+                          fi
                         fi
 
                         echo "✅ Task $TASK_ID completed via merge to main"

--- a/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
+++ b/infra/gitops/resources/github-webhooks/stage-aware-resume-sensor.yaml
@@ -63,7 +63,7 @@ spec:
             value: ["approved"]
           - path: body.review.user.login
             type: string
-            value: ["5dlabs-tess[bot]"]
+            value: ["tess-5dlabs"]
 
     # PR Merged - Resume workflows waiting for this
     - name: pr-merged-event


### PR DESCRIPTION
## Problem
After PR #38 was merged, task 2 didn't start because the PR title ("feat: bootstrap axum api project") didn't contain "Task 1".

The merge-to-main sensor only looked for task IDs in PR titles, but Factory creates PRs with conventional commit titles, not "Task N" titles.

## Solution
- Added fallback to extract task ID from PR labels () when not found in title
- Fixed Tess approval sensor username ( instead of )

## Impact
- Task 2 can now be manually triggered or will start automatically on next PR merge
- Future PRs will properly trigger next tasks even with conventional commit titles

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> <sup>[Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) is generating a summary for commit 52963462e28cd7e5136e2bae2cd461298e6f9b6c. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->